### PR TITLE
Clonable, injectable injector

### DIFF
--- a/src/injector.rs
+++ b/src/injector.rs
@@ -69,8 +69,8 @@ use types::*;
 /// Cloning the injector does not clone the providers inside of it. Instead,
 /// both injectors will use the same providers, meaning that an injector can be
 /// passed to a service as a dependency. The injector can be requested as
-/// itself without using a service pointer without needing to register it as a
-/// dependency in the builder.
+/// itself without using a service pointer. It does not need to be registered
+/// as a dependency in the builder beforehand.
 ///
 /// Note that requesting the injector inside of your services is generally bad
 /// practice, and is known as the service locator antipattern. This is mostly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //!     
 //!     // Now that we've registered all our providers and implementations, we
 //!     // can start relying on our container to create our services for us!
-//!     let mut injector = builder.build();
+//!     let injector = builder.build();
 //!     let user_service: Svc<UserService> = injector.get()?;
 //!     let _user = user_service.get_user("john");
 //!     

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,11 +3,11 @@ use crate::{InjectError, InjectResult, Injector, Interface, ServiceInfo, Svc};
 /// A request to an injector.
 pub trait Request: Sized {
     /// Performs the request to the injector.
-    fn request(injector: &mut Injector) -> InjectResult<Self>;
+    fn request(injector: &Injector) -> InjectResult<Self>;
 }
 
 impl<I: ?Sized + Interface> Request for Svc<I> {
-    fn request(injector: &mut Injector) -> InjectResult<Self> {
+    fn request(injector: &Injector) -> InjectResult<Self> {
         let implementation =
             injector.get_implementation(ServiceInfo::of::<I>());
         I::resolve(injector, implementation)
@@ -15,11 +15,17 @@ impl<I: ?Sized + Interface> Request for Svc<I> {
 }
 
 impl<R: Request> Request for Option<R> {
-    fn request(injector: &mut Injector) -> InjectResult<Self> {
+    fn request(injector: &Injector) -> InjectResult<Self> {
         match injector.get() {
             Ok(response) => Ok(Some(response)),
             Err(InjectError::MissingProvider { .. }) => Ok(None),
             Err(error) => Err(error),
         }
+    }
+}
+
+impl Request for Injector {
+    fn request(injector: &Injector) -> InjectResult<Self> {
+        Ok(injector.clone())
     }
 }

--- a/src/services/constant.rs
+++ b/src/services/constant.rs
@@ -31,7 +31,7 @@ where
 
     fn provide_typed(
         &mut self,
-        _injector: &mut Injector,
+        _injector: &Injector,
     ) -> InjectResult<Svc<Self::Result>> {
         Ok(self.result.clone())
     }
@@ -57,7 +57,7 @@ impl<T: Service> From<T> for ConstantProvider<T> {
 /// let mut builder = Injector::builder();
 /// builder.provide(constant(8i32));
 ///
-/// let mut injector = builder.build();
+/// let injector = builder.build();
 /// let value: Svc<i32> = injector.get().unwrap();
 ///
 /// assert_eq!(8, *value);
@@ -87,7 +87,7 @@ impl<T: Service> From<T> for ConstantProvider<T> {
 /// builder.provide(Foo::new.transient());
 /// builder.provide(constant(Mutex::new(0i32)));
 ///
-/// let mut injector = builder.build();
+/// let injector = builder.build();
 /// let foo: Svc<Foo> = injector.get().unwrap();
 /// let value: Svc<Mutex<i32>> = injector.get().unwrap();
 ///

--- a/src/services/func.rs
+++ b/src/services/func.rs
@@ -12,8 +12,8 @@ use crate::{InjectResult, Injector, Request, Service, Svc};
 ///
 /// # fn _no_run() {
 /// fn factory(foo: Svc<Foo>) -> Bar { todo!() }
-/// let mut injector: Injector = todo!();
-/// factory.invoke(&mut injector);
+/// let injector: Injector = todo!();
+/// factory.invoke(&injector);
 /// # }
 /// ```
 ///
@@ -25,7 +25,7 @@ where
     R: Service,
 {
     /// Invokes this service factory, creating an instance of the service.
-    fn invoke(&mut self, injector: &mut Injector) -> InjectResult<Svc<R>>;
+    fn invoke(&mut self, injector: &Injector) -> InjectResult<Svc<R>>;
 }
 
 macro_rules! impl_provider_function {
@@ -45,7 +45,7 @@ macro_rules! impl_provider_function {
             $($type_name: Request,)*
         {
             #[allow(unused_variables, unused_mut, unused_assignments, non_snake_case)]
-            fn invoke(&mut self, injector: &mut Injector) -> InjectResult<Svc<R>> {
+            fn invoke(&mut self, injector: &Injector) -> InjectResult<Svc<R>> {
                 let result = self($(
                     match injector.get::<$type_name>() {
                         Ok(dependency) => dependency,

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -14,14 +14,14 @@ pub trait Interface: Service {
     /// However, it is not unsound to return the wrong type. It is only unsafe
     /// for code to rely on that exact type being returned in an unsafe manner.
     fn resolve(
-        injector: &mut Injector,
+        injector: &Injector,
         implementation: Option<ServiceInfo>,
     ) -> InjectResult<Svc<Self>>;
 }
 
 impl<T: Service> Interface for T {
     fn resolve(
-        injector: &mut Injector,
+        injector: &Injector,
         implementation: Option<ServiceInfo>,
     ) -> InjectResult<Svc<Self>> {
         if let Some(implementation) = implementation {
@@ -82,7 +82,7 @@ macro_rules! interface {
     ($trait:tt = [$($(#[$attr:meta])* $impl:ty),* $(,)?]) => {
         impl $crate::Interface for dyn $trait {
             fn resolve(
-                injector: &mut $crate::Injector,
+                injector: &$crate::Injector,
                 implementation: Option<$crate::ServiceInfo>,
             ) -> $crate::InjectResult<$crate::Svc<Self>> {
                 match implementation {

--- a/src/services/providers.rs
+++ b/src/services/providers.rs
@@ -4,12 +4,12 @@ use crate::{DynSvc, InjectResult, Injector, Service, ServiceInfo, Svc};
 /// implementation of a service. This is automatically implemented for all
 /// types that implement `TypedProvider`, and `TypedProvider` should be
 /// preferred if possible to allow for stronger type checking.
-pub trait Provider: 'static {
+pub trait Provider: Service {
     /// The `ServiceInfo` which describes the type returned by this provider.
     fn result(&self) -> ServiceInfo;
 
     /// Provides an instance of the service.
-    fn provide(&mut self, injector: &mut Injector) -> InjectResult<DynSvc>;
+    fn provide(&mut self, injector: &Injector) -> InjectResult<DynSvc>;
 }
 
 impl<T> Provider for T
@@ -20,7 +20,7 @@ where
         ServiceInfo::of::<T::Result>()
     }
 
-    fn provide(&mut self, injector: &mut Injector) -> InjectResult<DynSvc> {
+    fn provide(&mut self, injector: &Injector) -> InjectResult<DynSvc> {
         let result = self.provide_typed(injector)?;
         Ok(result as DynSvc)
     }
@@ -44,7 +44,7 @@ where
 /// impl TypedProvider for FooProvider {
 ///     type Result = Foo;
 ///
-///     fn provide_typed(&mut self, _injector: &mut Injector) -> InjectResult<Svc<Self::Result>> {
+///     fn provide_typed(&mut self, _injector: &Injector) -> InjectResult<Svc<Self::Result>> {
 ///         Ok(Svc::new(Foo))
 ///     }
 /// }
@@ -52,7 +52,7 @@ where
 /// let mut builder = Injector::builder();
 /// builder.provide(FooProvider);
 ///
-/// let mut injector = builder.build();
+/// let injector = builder.build();
 /// let _foo: Svc<Foo> = injector.get().unwrap();
 /// ```
 pub trait TypedProvider: Provider {
@@ -63,6 +63,6 @@ pub trait TypedProvider: Provider {
     /// used to retrieve instances of any dependencies this service has.
     fn provide_typed(
         &mut self,
-        injector: &mut Injector,
+        injector: &Injector,
     ) -> InjectResult<Svc<Self::Result>>;
 }

--- a/src/services/singleton.rs
+++ b/src/services/singleton.rs
@@ -36,13 +36,13 @@ impl<D, R, F> TypedProvider for SingletonProvider<D, R, F>
 where
     D: 'static,
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, R> + Service,
 {
     type Result = R;
 
     fn provide_typed(
         &mut self,
-        injector: &mut Injector,
+        injector: &Injector,
     ) -> InjectResult<Svc<Self::Result>> {
         if let Some(ref service) = self.result {
             return Ok(service.clone());
@@ -76,7 +76,7 @@ where
     /// let mut builder = Injector::builder();
     /// builder.provide(Foo::default.singleton());
     ///
-    /// let mut injector = builder.build();
+    /// let injector = builder.build();
     /// let foo1: Svc<Foo> = injector.get().unwrap();
     /// let foo2: Svc<Foo> = injector.get().unwrap();
     ///

--- a/src/services/transient.rs
+++ b/src/services/transient.rs
@@ -34,13 +34,13 @@ impl<D, R, F> TypedProvider for TransientProvider<D, R, F>
 where
     D: 'static,
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, R> + Service,
 {
     type Result = R;
 
     fn provide_typed(
         &mut self,
-        injector: &mut Injector,
+        injector: &Injector,
     ) -> InjectResult<Svc<Self::Result>> {
         self.func.invoke(injector)
     }
@@ -68,7 +68,7 @@ where
     /// let mut builder = Injector::builder();
     /// builder.provide(Foo::default.transient());
     ///
-    /// let mut injector = builder.build();
+    /// let injector = builder.build();
     /// let foo1: Svc<Foo> = injector.get().unwrap();
     /// let foo2: Svc<Foo> = injector.get().unwrap();
     ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,13 +35,13 @@ fn can_make_svc1() {
     let mut builder = Injector::builder();
     builder.provide(Svc1::default.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let _service: Svc<Svc1> = injector.get().unwrap();
 }
 
 #[test]
 fn cant_make_svc1_when_no_provider() {
-    let mut injector = Injector::builder().build();
+    let injector = Injector::builder().build();
     let svc: InjectResult<Svc<Svc1>> = injector.get();
     match svc {
         Err(InjectError::MissingProvider { service_info })
@@ -64,7 +64,7 @@ fn can_make_svc3() {
     builder.provide(Svc2::new.transient());
     builder.provide(Svc3::new.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let _service: Svc<Svc3> = injector.get().unwrap();
 }
 
@@ -74,7 +74,7 @@ fn cant_make_svc3_when_no_provider_for_dependency() {
     builder.provide(Svc2::new.transient());
     builder.provide(Svc3::new.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     match injector.get::<Svc<Svc3>>() {
         Err(InjectError::MissingDependency {
             dependency_info, ..
@@ -100,7 +100,7 @@ fn singleton() {
     builder.provide(Svc2::new.transient());
     builder.provide(Svc3::new.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let svc1: Svc<Svc1> = injector.get().unwrap();
     let svc2: Svc<Svc2> = injector.get().unwrap();
     let svc3: Svc<Svc3> = injector.get().unwrap();
@@ -126,7 +126,7 @@ fn constants() {
     builder.provide(Svc2::new.transient());
     builder.provide(Svc3::new.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let svc1: Svc<Svc1> = injector.get().unwrap();
     let svc2: Svc<Svc2> = injector.get().unwrap();
     let svc3: Svc<Svc3> = injector.get().unwrap();
@@ -187,7 +187,7 @@ fn interfaces() {
     builder.implement::<dyn Foo, Svc1>();
     builder.provide(Svc4::new.transient());
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let svc: Svc<dyn Foo> = injector.get().unwrap();
 
     assert_eq!(4, svc.bar());
@@ -198,7 +198,7 @@ fn interfaces() {
     builder.provide(Svc2::new.transient());
     builder.implement::<dyn Foo, Svc2>();
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let svc: Svc<dyn Foo> = injector.get().unwrap();
 
     assert_eq!(5, svc.bar());
@@ -217,6 +217,6 @@ fn a() {
     builder.provide(Bar::default.singleton());
     builder.implement::<dyn Foo, Bar>();
 
-    let mut injector = builder.build();
+    let injector = builder.build();
     let _bar: Svc<dyn Foo> = injector.get().unwrap();
 }


### PR DESCRIPTION
- Allows the injector to be cloned. Cloning it returns a new injector with pointers to the same provider map and implementation map.
- Makes the injector no longer require `&mut self`, allowing it to be easily used in multi-threaded contexts. This is a result of making the inner state of the injector shared across each clone of it.
- Allows the injector to be injected into services. This allows for custom service factories.
