### PR TITLE
Add support for multi-injection

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,10 +1,9 @@
-use crate::{Injector, Interface, Provider, ProviderMap, ServiceInfo};
+use crate::{Injector, Provider, ProviderMap};
 
 /// A builder for an `Injector`.
 #[derive(Default)]
 pub struct InjectorBuilder {
     providers: ProviderMap,
-    // implementations: ImplementationMap,
 }
 
 impl InjectorBuilder {
@@ -13,19 +12,6 @@ impl InjectorBuilder {
     pub fn provide<P: Provider>(&mut self, provider: P) {
         self.providers
             .entry(provider.result())
-            .or_insert_with(|| Some(Vec::new()))
-            .as_mut()
-            .unwrap()
-            .push(Box::new(provider));
-    }
-
-    pub fn provide_as<I, P>(&mut self, provider: P)
-    where
-        I: ?Sized + Interface,
-        P: Provider,
-    {
-        self.providers
-            .entry(ServiceInfo::of::<I>())
             .or_insert_with(|| Some(Vec::new()))
             .as_mut()
             .unwrap()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,12 +9,13 @@ pub struct InjectorBuilder {
 impl InjectorBuilder {
     /// Assigns the provider for a service type. Multiple providers can be
     /// registered for a service.
+    #[allow(clippy::clippy::missing_panics_doc)]
     pub fn provide<P: Provider>(&mut self, provider: P) {
         self.providers
             .entry(provider.result())
             .or_insert_with(|| Some(Vec::new()))
             .as_mut()
-            .unwrap()
+            .unwrap() // Should never panic
             .push(Box::new(provider));
     }
 

--- a/src/injector.rs
+++ b/src/injector.rs
@@ -248,7 +248,7 @@ impl Injector {
                     })
                 })
                 .transpose()?
-                .unwrap_or_else(|| Vec::new()))
+                .unwrap_or_else(Vec::new))
         })?;
 
         Ok(Services {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -57,9 +57,10 @@ pub struct Services<I: ?Sized + Interface> {
 impl<I: ?Sized + Interface> Services<I> {
     /// Lazily gets all the implementations of this interface. Each service
     /// will be requested on demand rather than all at once.
+    #[allow(clippy::missing_panics_doc)]
     pub fn get_all(&mut self) -> ServicesIter<'_, I> {
         ServicesIter {
-            providers: self.providers.as_mut().unwrap(),
+            providers: self.providers.as_mut().unwrap(), // Should never panic
             injector: &self.injector,
             index: 0,
             marker: PhantomData,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,16 +14,16 @@ use std::marker::PhantomData;
 ///
 /// An iterator over all the implementations of an interface. Each service is
 /// activated on demand.
-/// 
+///
 /// ```
 /// use runtime_injector::{Injector, Services, Svc, IntoTransient, interface, TypedProvider};
-/// 
+///
 /// trait Fooable: Send + Sync {
 ///     fn baz(&self) {}
 /// }
 ///
 /// interface!(Fooable = [Foo, Bar]);
-/// 
+///
 /// #[derive(Default)]
 /// struct Foo;
 /// impl Fooable for Foo {}
@@ -31,11 +31,11 @@ use std::marker::PhantomData;
 /// #[derive(Default)]
 /// struct Bar;
 /// impl Fooable for Bar {}
-/// 
+///
 /// let mut builder = Injector::builder();
 /// builder.provide(Foo::default.transient().with_interface::<dyn Fooable>());
 /// builder.provide(Bar::default.transient().with_interface::<dyn Fooable>());
-/// 
+///
 /// let injector = builder.build();
 /// let mut counter = 0;
 /// let mut fooables: Services<dyn Fooable> = injector.get().unwrap();
@@ -43,7 +43,7 @@ use std::marker::PhantomData;
 ///     counter += 1;
 ///     foo.unwrap().baz();
 /// }
-/// 
+///
 /// assert_eq!(2, counter);
 /// ```
 pub struct Services<I: ?Sized + Interface> {
@@ -119,11 +119,11 @@ impl<I: ?Sized + Interface> Drop for Services<I> {
 
 /// An iterator over all the implementations of an interface. Each service is
 /// activated on demand.
-/// 
+///
 /// ```
 /// use runtime_injector::{Injector, Services, Svc, IntoTransient, constant};
 /// use std::sync::Mutex;
-/// 
+///
 /// struct Foo;
 ///
 /// fn make_foo(counter: Svc<Mutex<usize>>) -> Foo {
@@ -132,15 +132,15 @@ impl<I: ?Sized + Interface> Drop for Services<I> {
 ///     *counter += 1;
 ///     Foo
 /// }
-/// 
+///
 /// let mut builder = Injector::builder();
 /// builder.provide(constant(Mutex::new(0usize)));
 /// builder.provide(make_foo.transient());
-/// 
+///
 /// let injector = builder.build();
 /// let counter: Svc<Mutex<usize>> = injector.get().unwrap();
 /// let mut foos: Services<Foo> = injector.get().unwrap();
-/// 
+///
 /// let mut iter = foos.get_all();
 /// assert_eq!(0, *counter.lock().unwrap());
 /// assert!(iter.next().is_some());

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,98 @@
+use crate::{
+    InjectError, InjectResult, Injector, Interface, MapContainer,
+    MapContainerEx, Provider, ProviderMap, Service, ServiceInfo, Svc,
+};
+use std::marker::PhantomData;
+
+pub struct Services<I: ?Sized + Interface> {
+    pub(crate) injector: Injector,
+    pub(crate) service_info: ServiceInfo,
+    pub(crate) provider_map: MapContainer<ProviderMap>,
+    pub(crate) providers: Option<Vec<Box<dyn Provider>>>,
+    pub(crate) marker: PhantomData<*const I>,
+}
+
+impl<I: ?Sized + Interface> Services<I> {
+    pub fn get_all(&mut self) -> ServicesIter<'_, I> {
+        ServicesIter {
+            providers: self.providers.as_mut().unwrap(),
+            injector: &self.injector,
+            service_info: self.service_info,
+            index: 0,
+            marker: PhantomData,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.providers.as_ref().unwrap().len()
+    }
+}
+
+impl<I: ?Sized + Interface> Drop for Services<I> {
+    fn drop(&mut self) {
+        let Services {
+            ref service_info,
+            ref mut provider_map,
+            ref mut providers,
+            ..
+        } = self;
+
+        let result = provider_map.with_inner_mut(|provider_map| {
+            let provider_entry =
+                provider_map.get_mut(service_info).ok_or_else(|| {
+                    InjectError::InternalError(format!(
+                        "activated provider for {} is no longer registered",
+                        service_info.name()
+                    ))
+                })?;
+
+            if provider_entry.replace(providers.take().unwrap()).is_some() {
+                Err(InjectError::InternalError(format!(
+                    "another provider for {} was added during its activation",
+                    service_info.name()
+                )))
+            } else {
+                Ok(())
+            }
+        });
+
+        if let Err(error) = result {
+            eprintln!(
+                "An error occurred while releasing providiers for {}: {}",
+                service_info.name(),
+                error
+            );
+        }
+    }
+}
+
+pub struct ServicesIter<'a, I: ?Sized + Interface> {
+    providers: &'a mut Vec<Box<dyn Provider>>,
+    injector: &'a Injector,
+    service_info: ServiceInfo,
+    index: usize,
+    marker: PhantomData<*const I>,
+}
+
+impl<'a, I: ?Sized + Interface> Iterator for ServicesIter<'a, I> {
+    type Item = InjectResult<Svc<I>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.providers.get_mut(self.index) {
+            None => None,
+            Some(provider) => {
+                self.index += 1;
+                Some(
+                    provider
+                        .provide(self.injector)
+                        .and_then(|result| I::downcast(result)),
+                )
+            }
+        }
+    }
+}
+
+// TODO
+pub struct Interfaces<T: ?Sized + Interface> {
+    marker: PhantomData<*const T>,
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -68,14 +68,22 @@ impl<I: ?Sized + Interface> Services<I> {
 
     /// Gets the number of implementations of this interface.
     #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn len(&self) -> usize {
-        self.providers.as_ref().unwrap().len()
+        self.providers
+            .as_ref()
+            .unwrap() // Should never panic
+            .len()
     }
 
     /// Returns `true` if there are no implementations of this interface.
     #[must_use]
+    #[allow(clippy::clippy::missing_panics_doc)]
     pub fn is_empty(&self) -> bool {
-        self.providers.as_ref().unwrap().is_empty()
+        self.providers
+            .as_ref()
+            .unwrap() // Should never panic
+            .is_empty()
     }
 }
 
@@ -97,6 +105,7 @@ impl<I: ?Sized + Interface> Drop for Services<I> {
                     ))
                 })?;
 
+            #[allow(clippy::missing_panics_doc)] // Should never panic
             if provider_entry.replace(providers.take().unwrap()).is_some() {
                 Err(InjectError::InternalError(format!(
                     "another provider for {} was added during its activation",

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,6 @@
 use crate::{
     InjectError, InjectResult, Injector, Interface, MapContainer,
-    MapContainerEx, Provider, ProviderMap, Service, ServiceInfo, Svc,
+    MapContainerEx, Provider, ProviderMap, ServiceInfo, Svc,
 };
 use std::marker::PhantomData;
 
@@ -17,7 +17,6 @@ impl<I: ?Sized + Interface> Services<I> {
         ServicesIter {
             providers: self.providers.as_mut().unwrap(),
             injector: &self.injector,
-            service_info: self.service_info,
             index: 0,
             marker: PhantomData,
         }
@@ -69,7 +68,6 @@ impl<I: ?Sized + Interface> Drop for Services<I> {
 pub struct ServicesIter<'a, I: ?Sized + Interface> {
     providers: &'a mut Vec<Box<dyn Provider>>,
     injector: &'a Injector,
-    service_info: ServiceInfo,
     index: usize,
     marker: PhantomData<*const I>,
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 /// ```
 /// use runtime_injector::{Injector, Services, Svc, IntoTransient, interface, TypedProvider};
 /// 
-/// trait Fooable {
+/// trait Fooable: Send + Sync {
 ///     fn baz(&self) {}
 /// }
 ///
@@ -67,8 +67,15 @@ impl<I: ?Sized + Interface> Services<I> {
     }
 
     /// Gets the number of implementations of this interface.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.providers.as_ref().unwrap().len()
+    }
+
+    /// Returns `true` if there are no implementations of this interface.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.providers.as_ref().unwrap().is_empty()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! # Example
 //!
 //! ```
-//! use runtime_injector::{interface, Injector, Svc, IntoSingleton};
+//! use runtime_injector::{interface, Injector, Svc, IntoSingleton, TypedProvider};
 //! use std::error::Error;
 //!
 //! // Some type that represents a user
@@ -122,15 +122,13 @@
 //!     // constructing instances of those types that we aren't actually using.
 //!     let mut builder = Injector::builder();
 //!     builder.provide(UserService::new.singleton());
-//!     builder.provide(SqlDataService::default.singleton());
-//!     builder.provide(MockDataService::default.singleton());
 //!
 //!     // Note that we can register closures as providers as well
 //!     builder.provide((|_: Svc<dyn DataService>| "Hello, world!").singleton());
 //!     builder.provide((|_: Option<Svc<i32>>| 120.9).singleton());
 //!     
 //!     // Let's choose to use the MockDataService as our data service
-//!     builder.implement::<dyn DataService, MockDataService>();
+//!     builder.provide(MockDataService::default.singleton().with_interface::<dyn DataService>());
 //!     
 //!     // Now that we've registered all our providers and implementations, we
 //!     // can start relying on our container to create our services for us!
@@ -143,7 +141,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::missing_errors_doc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,13 @@ compile_error!(
 
 mod builder;
 mod injector;
+mod iter;
 mod request;
 mod services;
 
 pub use builder::*;
 pub use injector::*;
+pub use iter::*;
 pub use request::*;
 pub use services::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::missing_errors_doc,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,6 @@
-use crate::{InjectError, InjectResult, Injector, Interface, ServiceInfo, Services, Svc};
+use crate::{
+    InjectError, InjectResult, Injector, Interface, ServiceInfo, Services, Svc,
+};
 
 /// A request to an injector.
 pub trait Request: Sized {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use crate::{InjectError, InjectResult, Injector, Interface, ServiceInfo, Svc};
+use crate::{InjectError, InjectResult, Injector, Interface, ServiceInfo, Services, Svc};
 
 /// A request to an injector.
 pub trait Request: Sized {
@@ -6,26 +6,51 @@ pub trait Request: Sized {
     fn request(injector: &Injector) -> InjectResult<Self>;
 }
 
-impl<I: ?Sized + Interface> Request for Svc<I> {
+impl Request for Injector {
     fn request(injector: &Injector) -> InjectResult<Self> {
-        let implementation =
-            injector.get_implementation(ServiceInfo::of::<I>());
-        I::resolve(injector, implementation)
+        Ok(injector.clone())
     }
 }
 
-impl<R: Request> Request for Option<R> {
+impl<I: ?Sized + Interface> Request for Svc<I> {
+    fn request(injector: &Injector) -> InjectResult<Self> {
+        let mut services: Services<I> = injector.get_service()?;
+        if services.len() > 1 {
+            Err(InjectError::MultipleProviders {
+                service_info: ServiceInfo::of::<I>(),
+                providers: services.len(),
+            })
+        } else {
+            let service = services.get_all().next().ok_or(
+                InjectError::MissingProvider {
+                    service_info: ServiceInfo::of::<I>(),
+                },
+            )??;
+
+            Ok(service)
+        }
+    }
+}
+
+impl<I: ?Sized + Interface> Request for Services<I> {
+    fn request(injector: &Injector) -> InjectResult<Self> {
+        injector.get_service()
+    }
+}
+
+impl<I: ?Sized + Interface> Request for Vec<Svc<I>> {
+    fn request(injector: &Injector) -> InjectResult<Self> {
+        let mut impls: Services<I> = injector.get()?;
+        impls.get_all().collect()
+    }
+}
+
+impl<I: ?Sized + Interface> Request for Option<Svc<I>> {
     fn request(injector: &Injector) -> InjectResult<Self> {
         match injector.get() {
             Ok(response) => Ok(Some(response)),
             Err(InjectError::MissingProvider { .. }) => Ok(None),
             Err(error) => Err(error),
         }
-    }
-}
-
-impl Request for Injector {
-    fn request(injector: &Injector) -> InjectResult<Self> {
-        Ok(injector.clone())
     }
 }

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -14,6 +14,7 @@ pub trait Interface: Service {
 }
 
 impl<T: Service> Interface for T {
+    #[allow(clippy::map_err_ignore)]
     fn downcast(service: DynSvc) -> InjectResult<Svc<Self>> {
         service
             .downcast()

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -8,6 +8,8 @@ use crate::{DynSvc, InjectError, InjectResult, Service, ServiceInfo, Svc};
 /// declared explicitly before use. This trait should usually be implemented
 /// by the `interface!` macro.
 pub trait Interface: Service {
+    /// Downcasts a dynamic service pointer into a service pointer of this
+    /// interface type.
     fn downcast(service: DynSvc) -> InjectResult<Svc<Self>>;
 }
 

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -1,4 +1,4 @@
-use crate::{InjectError, InjectResult, Injector, Service, ServiceInfo, Svc};
+use crate::{DynSvc, InjectError, InjectResult, Service, ServiceInfo, Svc};
 
 /// Indicates that a type can resolve services. The most basic implementation
 /// of this trait is that each sized service type can resolve itself. This is
@@ -8,33 +8,16 @@ use crate::{InjectError, InjectResult, Injector, Service, ServiceInfo, Svc};
 /// declared explicitly before use. This trait should usually be implemented
 /// by the `interface!` macro.
 pub trait Interface: Service {
-    /// Attempts to resolve a service which implements this interface. If an
-    /// implementation type is provided, this **should** attempt to return an
-    /// instance of that type. If it cannot, then this should return an error.
-    /// However, it is not unsound to return the wrong type. It is only unsafe
-    /// for code to rely on that exact type being returned in an unsafe manner.
-    fn resolve(
-        injector: &Injector,
-        implementation: Option<ServiceInfo>,
-    ) -> InjectResult<Svc<Self>>;
+    fn downcast(service: DynSvc) -> InjectResult<Svc<Self>>;
 }
 
 impl<T: Service> Interface for T {
-    fn resolve(
-        injector: &Injector,
-        implementation: Option<ServiceInfo>,
-    ) -> InjectResult<Svc<Self>> {
-        if let Some(implementation) = implementation {
-            let service_info = ServiceInfo::of::<Self>();
-            if service_info != implementation {
-                return Err(InjectError::InvalidImplementation {
-                    service_info,
-                    implementation,
-                });
-            }
-        }
-
-        injector.get_exact()
+    fn downcast(service: DynSvc) -> InjectResult<Svc<Self>> {
+        service
+            .downcast()
+            .map_err(|_| InjectError::InvalidProvider {
+                service_info: ServiceInfo::of::<Self>(),
+            })
     }
 }
 
@@ -81,25 +64,17 @@ impl<T: Service> InterfaceFor<T> for T {}
 macro_rules! interface {
     ($trait:tt = [$($(#[$attr:meta])* $impl:ty),* $(,)?]) => {
         impl $crate::Interface for dyn $trait {
-            fn resolve(
-                injector: &$crate::Injector,
-                implementation: Option<$crate::ServiceInfo>,
-            ) -> $crate::InjectResult<$crate::Svc<Self>> {
-                match implementation {
-                    $(
-                        $(#[$attr])*
-                        Some(implementation) if implementation == $crate::ServiceInfo::of::<$impl>() => {
-                            Ok(injector.get::<$crate::Svc<$impl>>()? as $crate::Svc<Self>)
-                        }
-                    ),*
-                    Some(implementation) => {
-                        Err($crate::InjectError::InvalidImplementation {
-                            service_info: $crate::ServiceInfo::of::<Self>(),
-                            implementation,
-                        })
+            #[allow(unused_assignments)]
+            fn downcast(mut service: $crate::DynSvc) -> $crate::InjectResult<$crate::Svc<Self>> {
+                $(
+                    $(#[$attr])*
+                    match service.downcast::<$impl>() {
+                        Ok(downcasted) => return Ok(downcasted as $crate::Svc<Self>),
+                        Err(input) => service = input,
                     }
-                    None => Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
-                }
+                )*
+
+                Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
             }
         }
 

--- a/src/services/providers.rs
+++ b/src/services/providers.rs
@@ -81,9 +81,9 @@ pub trait TypedProvider: Sized + Provider {
     /// trait Fooable: Send + Sync {
     ///     fn bar(&self) {}
     /// }
-    /// 
+    ///
     /// interface!(Fooable = [Foo]);
-    /// 
+    ///
     /// #[derive(Default)]
     /// struct Foo;
     /// impl Fooable for Foo {}

--- a/src/services/providers.rs
+++ b/src/services/providers.rs
@@ -78,14 +78,15 @@ pub trait TypedProvider: Sized + Provider {
     /// ```
     /// use runtime_injector::{TypedProvider, Injector, IntoSingleton, InjectResult, Svc, interface};
     ///
-    /// trait Fooable {
-    ///     fn bar() {}
+    /// trait Fooable: Send + Sync {
+    ///     fn bar(&self) {}
     /// }
     /// 
     /// interface!(Fooable = [Foo]);
     /// 
     /// #[derive(Default)]
     /// struct Foo;
+    /// impl Fooable for Foo {}
     ///
     /// let mut builder = Injector::builder();
     /// builder.provide(Foo::default.singleton().with_interface::<dyn Fooable>());
@@ -96,7 +97,7 @@ pub trait TypedProvider: Sized + Provider {
     /// fooable.bar();
     ///
     /// // It can't be requested through its original type
-    /// assert!(injector.get::<Svc<Foo>>().is_none());
+    /// assert!(injector.get::<Svc<Foo>>().is_err());
     /// ```
     fn with_interface<I: ?Sized + InterfaceFor<Self::Result>>(
         self,

--- a/src/services/providers.rs
+++ b/src/services/providers.rs
@@ -1,4 +1,7 @@
-use crate::{DynSvc, InjectResult, Injector, Service, ServiceInfo, Svc};
+use crate::{
+    DynSvc, InjectError, InjectResult, Injector, MapContainer, MapContainerEx,
+    ProviderMap, Service, ServiceInfo, Svc,
+};
 
 /// Weakly typed service provider. Given an injector, this will provide an
 /// implementation of a service. This is automatically implemented for all
@@ -65,4 +68,24 @@ pub trait TypedProvider: Provider {
         &mut self,
         injector: &Injector,
     ) -> InjectResult<Svc<Self::Result>>;
+}
+
+pub struct ServiceIter<'a> {
+    providers: &'a mut Vec<Box<dyn Provider>>,
+    injector: &'a Injector,
+    index: usize,
+}
+
+impl<'a> Iterator for ServiceIter<'a> {
+    type Item = InjectResult<DynSvc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.providers.get_mut(self.index) {
+            Some(provider) => {
+                self.index += 1;
+                Some(provider.provide(self.injector))
+            }
+            None => None,
+        }
+    }
 }

--- a/src/services/service.rs
+++ b/src/services/service.rs
@@ -128,6 +128,18 @@ pub enum InjectError {
         service_info: ServiceInfo,
     },
 
+    /// The requested service has too many providers registered.
+    #[display(
+        fmt = "the requested service has {} providers registered (did you mean to request a Services<T> instead?)",
+        providers
+    )]
+    MultipleProviders {
+        /// The service that was requested.
+        service_info: ServiceInfo,
+        /// The number of providers registered for that service.
+        providers: usize,
+    },
+
     /// An unexpected error has occurred. This is usually caused by a bug in
     /// the library itself.
     #[display(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -182,10 +182,7 @@ fn interfaces() {
 
     // Svc1
     let mut builder = Injector::builder();
-    builder.provide(Svc1::default.transient());
-    builder.provide(Svc2::new.transient());
-    builder.implement::<dyn Foo, Svc1>();
-    builder.provide(Svc4::new.transient());
+    builder.provide_as::<dyn Foo, _>(Svc1::default.transient());
 
     let injector = builder.build();
     let svc: Svc<dyn Foo> = injector.get().unwrap();
@@ -195,13 +192,23 @@ fn interfaces() {
     // Svc2
     let mut builder = Injector::builder();
     builder.provide(Svc1::default.transient());
-    builder.provide(Svc2::new.transient());
-    builder.implement::<dyn Foo, Svc2>();
+    builder.provide_as::<dyn Foo, _>(Svc2::new.transient());
 
     let injector = builder.build();
     let svc: Svc<dyn Foo> = injector.get().unwrap();
 
     assert_eq!(5, svc.bar());
+
+    // Svc4
+    let mut builder = Injector::builder();
+    builder.provide(Svc1::default.transient());
+    builder.provide_as::<dyn Foo, _>(Svc2::new.transient());
+    builder.provide(Svc4::new.transient());
+
+    let injector = builder.build();
+    let svc: Svc<Svc4> = injector.get().unwrap();
+
+    assert_eq!(5, svc.foo.bar());
 }
 
 #[test]
@@ -214,8 +221,7 @@ fn a() {
     impl Foo for Bar {}
 
     let mut builder = Injector::builder();
-    builder.provide(Bar::default.singleton());
-    builder.implement::<dyn Foo, Bar>();
+    builder.provide_as::<dyn Foo, _>(Bar::default.singleton());
 
     let injector = builder.build();
     let _bar: Svc<dyn Foo> = injector.get().unwrap();


### PR DESCRIPTION
Adds support for multi-injection, allowing multiple providers to be registered per type.

This completely changes how injection is done and is a major breaking change.

Closes #5 