### PR TITLE
Add request info object to track request path

### DIFF
--- a/src/injector.rs
+++ b/src/injector.rs
@@ -156,6 +156,8 @@ impl Injector {
     ///   much sense to request this directly from the injector itself, this
     ///   allows the injector to be requested as a dependency inside of
     ///   services (for instance, factories).
+    /// - [`RequestInfo`]: Requests information about the current request,
+    ///   including the current resolution path.
     ///
     /// See the [documentation for `Request`](Request) for more information on
     /// what can be requested.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,13 +161,13 @@ compile_error!(
 mod builder;
 mod injector;
 mod iter;
-mod request;
+mod requests;
 mod services;
 
 pub use builder::*;
 pub use injector::*;
 pub use iter::*;
-pub use request::*;
+pub use requests::*;
 pub use services::*;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,11 @@
 //!     // Note that we can register closures as providers as well
 //!     builder.provide((|_: Svc<dyn DataService>| "Hello, world!").singleton());
 //!     builder.provide((|_: Option<Svc<i32>>| 120.9).singleton());
+//!
+//!     // Simple tuple structs can be registered as services directly without
+//!     // defining any additional constructors
+//!     struct Foo(Svc<dyn DataService>);
+//!     builder.provide(Foo.singleton());
 //!     
 //!     // Let's choose to use the MockDataService as our data service
 //!     builder.provide(MockDataService::default.singleton().with_interface::<dyn DataService>());

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -1,0 +1,5 @@
+mod request;
+mod request_info;
+
+pub use request::*;
+pub use request_info::*;

--- a/src/requests/request_info.rs
+++ b/src/requests/request_info.rs
@@ -1,0 +1,76 @@
+use crate::ServiceInfo;
+
+/// Information about an active request.
+#[derive(Clone, Debug)]
+pub struct RequestInfo {
+    service_path: Vec<ServiceInfo>,
+}
+
+impl RequestInfo {
+    /// Creates a new, empty instance of [`RequestInfo`].
+    #[must_use]
+    pub fn new() -> Self {
+        RequestInfo {
+            service_path: Vec::new(),
+        }
+    }
+
+    /// Creates a new child instance of [`RequestInfo`] with the given service
+    /// appended to the end of the request path.
+    #[must_use]
+    pub fn with_request(&self, service: ServiceInfo) -> Self {
+        let mut child = self.clone();
+        child.service_path.push(service);
+        child
+    }
+
+    /// Gets the current request path. This can be used to configure a service
+    /// based on what it's being injected into.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use runtime_injector::{Injector, IntoTransient, RequestInfo, ServiceInfo, Svc};
+    ///
+    /// struct Foo(pub Svc<Baz>);
+    /// struct Bar(pub Svc<Baz>);
+    /// struct Baz(pub i32);
+    ///
+    /// impl Baz {
+    ///     pub fn new(request_info: RequestInfo) -> Self {
+    ///         let service_path = request_info.service_path();
+    ///         let value = match service_path.get(0) {
+    ///             Some(root) if root == &ServiceInfo::of::<Foo>() => 1,
+    ///             Some(root) if root == &ServiceInfo::of::<Bar>() => 2,
+    ///             _ => 0,
+    ///         };
+    ///         
+    ///         Baz(value)
+    ///     }
+    /// }
+    ///
+    /// let mut builder = Injector::builder();
+    /// builder.provide(Foo.transient());
+    /// builder.provide(Bar.transient());
+    /// builder.provide(Baz::new.transient());
+    ///
+    /// let injector = builder.build();
+    /// let foo: Svc<Foo> = injector.get().unwrap();
+    /// let bar: Svc<Bar> = injector.get().unwrap();
+    /// let baz: Svc<Baz> = injector.get().unwrap();
+    ///
+    /// assert_eq!(1, foo.0.0);
+    /// assert_eq!(2, bar.0.0);
+    /// assert_eq!(0, baz.0);
+    /// ```
+    #[must_use]
+    pub fn service_path(&self) -> &[ServiceInfo] {
+        &self.service_path
+    }
+}
+
+impl Default for RequestInfo {
+    fn default() -> Self {
+        RequestInfo::new()
+    }
+}

--- a/src/services/constant.rs
+++ b/src/services/constant.rs
@@ -1,4 +1,4 @@
-use crate::{InjectResult, Injector, Service, Svc, TypedProvider};
+use crate::{InjectResult, Injector, RequestInfo, Service, Svc, TypedProvider};
 
 /// A provider which returns a constant, predetermined value. Note that this is
 /// technically a singleton service in that it does not recreate the value each
@@ -32,6 +32,7 @@ where
     fn provide_typed(
         &mut self,
         _injector: &Injector,
+        _request_info: RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
         Ok(self.result.clone())
     }

--- a/src/services/func.rs
+++ b/src/services/func.rs
@@ -1,11 +1,13 @@
-use crate::{InjectResult, Injector, Request, Service, Svc};
+use crate::{
+    InjectResult, Injector, Request, RequestInfo, Service, ServiceInfo, Svc,
+};
 
 /// A factory for creating instances of a service. All functions of arity 12 or
 /// less are automatically service factories if the arguments to that function
 /// are valid service requests and the return value is a valid service type.
 ///
 /// ```
-/// use runtime_injector::{ServiceFactory, Injector, Svc};
+/// use runtime_injector::{ServiceFactory, Injector, Svc, RequestInfo};
 ///
 /// struct Foo;
 /// struct Bar;
@@ -13,7 +15,7 @@ use crate::{InjectResult, Injector, Request, Service, Svc};
 /// # fn _no_run() {
 /// fn factory(foo: Svc<Foo>) -> Bar { todo!() }
 /// let injector: Injector = todo!();
-/// factory.invoke(&injector);
+/// factory.invoke(&injector, RequestInfo::new());
 /// # }
 /// ```
 ///
@@ -25,7 +27,11 @@ where
     R: Service,
 {
     /// Invokes this service factory, creating an instance of the service.
-    fn invoke(&mut self, injector: &Injector) -> InjectResult<Svc<R>>;
+    fn invoke(
+        &mut self,
+        injector: &Injector,
+        request_info: RequestInfo,
+    ) -> InjectResult<Svc<R>>;
 }
 
 macro_rules! impl_provider_function {
@@ -44,9 +50,10 @@ macro_rules! impl_provider_function {
             $($type_name: Request,)*
         {
             #[allow(unused_variables, unused_mut, unused_assignments, non_snake_case)]
-            fn invoke(&mut self, injector: &Injector) -> InjectResult<Svc<R>> {
+            fn invoke(&mut self, injector: &Injector, request_info: RequestInfo) -> InjectResult<Svc<R>> {
+                let request_info = request_info.with_request(ServiceInfo::of::<R>());
                 let result = self($(
-                    match injector.get::<$type_name>() {
+                    match <$type_name as Request>::request(&injector, request_info.clone()) {
                         Ok(dependency) => dependency,
                         Err($crate::InjectError::MissingProvider { service_info }) => {
                             return Err($crate::InjectError::MissingDependency {

--- a/src/services/singleton.rs
+++ b/src/services/singleton.rs
@@ -1,5 +1,6 @@
 use crate::{
-    InjectResult, Injector, Service, ServiceFactory, Svc, TypedProvider,
+    InjectResult, Injector, RequestInfo, Service, ServiceFactory, Svc,
+    TypedProvider,
 };
 use std::marker::PhantomData;
 
@@ -43,12 +44,13 @@ where
     fn provide_typed(
         &mut self,
         injector: &Injector,
+        request_info: RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
         if let Some(ref service) = self.result {
             return Ok(service.clone());
         }
 
-        let result = self.func.invoke(injector)?;
+        let result = self.func.invoke(injector, request_info)?;
         self.result = Some(result.clone());
         Ok(result)
     }

--- a/src/services/transient.rs
+++ b/src/services/transient.rs
@@ -1,5 +1,6 @@
 use crate::{
-    InjectResult, Injector, Service, ServiceFactory, Svc, TypedProvider,
+    InjectResult, Injector, RequestInfo, Service, ServiceFactory, Svc,
+    TypedProvider,
 };
 use std::marker::PhantomData;
 
@@ -41,8 +42,9 @@ where
     fn provide_typed(
         &mut self,
         injector: &Injector,
+        request_info: RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
-        self.func.invoke(injector)
+        self.func.invoke(injector, request_info)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -240,22 +240,11 @@ fn multi_injection() {
 #[test]
 fn injector_returns_error_on_cycles() {
     struct Foo(Svc<Bar>);
-    impl Foo {
-        fn new(bar: Svc<Bar>) -> Self {
-            Foo(bar)
-        }
-    }
-
     struct Bar(Svc<Foo>);
-    impl Bar {
-        fn new(foo: Svc<Foo>) -> Self {
-            Bar(foo)
-        }
-    }
-
+    
     let mut builder = Injector::builder();
-    builder.provide(Foo::new.singleton());
-    builder.provide(Bar::new.singleton());
+    builder.provide(Foo.singleton());
+    builder.provide(Bar.singleton());
 
     let injector = builder.build();
     match injector.get::<Svc<Foo>>() {


### PR DESCRIPTION
Adds a `RequestInfo` object to track information about the current request when resolving services. Currently, this only tracks the service resolution path, but later can be extended to include additional parameters that services can use to configure how they are created.

This also lowers the visibility of `Injector::get_service::<T>()` since its signature is being changed and it is redundant with `Injector::get::<Services<T>>()`.

Closes #6 