### PR TITLE
Added modules and define_module macro

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,7 +22,7 @@ impl InjectorBuilder {
 
     /// Adds all the providers registered in a module. This may cause multiple
     /// providers to be registered for the same service.
-    #[allow(clippy::clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]
     pub fn add_module(&mut self, module: Module) {
         for (result, module_providers) in module.providers {
             // Should never panic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! // Specify which types implement the DataService interface. This does not
 //! // determine the actual implementation used. It only registers the types as
 //! // possible implementations of the DataService interface.
-//! interface!(DataService = [ SqlDataService, MockDataService ]);
+//! interface!(DataService = [SqlDataService, MockDataService]);
 //!
 //! // Here's another service our application uses. This service depends on our
 //! // data service, however it doesn't care how that service is actually

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,10 @@
 //! # Example
 //!
 //! ```
-//! use runtime_injector::{interface, Injector, Svc, IntoSingleton, TypedProvider};
+//! use runtime_injector::{
+//!     define_module, Module, interface, Injector, Svc, IntoSingleton,
+//!     TypedProvider
+//! };
 //! use std::error::Error;
 //!
 //! // Some type that represents a user
@@ -123,18 +126,28 @@
 //!     let mut builder = Injector::builder();
 //!     builder.provide(UserService::new.singleton());
 //!
-//!     // Note that we can register closures as providers as well
-//!     builder.provide((|_: Svc<dyn DataService>| "Hello, world!").singleton());
-//!     builder.provide((|_: Option<Svc<i32>>| 120.9).singleton());
-//!
-//!     // Simple tuple structs can be registered as services directly without
-//!     // defining any additional constructors
 //!     struct Foo(Svc<dyn DataService>);
-//!     builder.provide(Foo.singleton());
 //!     
-//!     // Let's choose to use the MockDataService as our data service
-//!     builder.provide(MockDataService::default.singleton().with_interface::<dyn DataService>());
-//!     
+//!     // Modules can be defined via the define_module! macro
+//!     let module = define_module! {
+//!         services = [
+//!             // Simple tuple structs can be registered as services directly without
+//!             // defining any additional constructors
+//!             Foo.singleton(),
+//!             
+//!             // Note that we can register closures as providers as well
+//!             (|_: Svc<dyn DataService>| "Hello, world!").singleton(),
+//!             (|_: Option<Svc<i32>>| 120.9).singleton(),
+//!         ],
+//!         interfaces = {
+//!             // Let's choose to use the MockDataService as our data service
+//!             dyn DataService = [MockDataService::default.singleton()],
+//!         },
+//!     };
+//!
+//!     // Register the module with our injector
+//!     builder.add_module(module);
+//!
 //!     // Now that we've registered all our providers and implementations, we
 //!     // can start relying on our container to create our services for us!
 //!     let injector = builder.build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,12 +166,14 @@ compile_error!(
 mod builder;
 mod injector;
 mod iter;
+mod module;
 mod requests;
 mod services;
 
 pub use builder::*;
 pub use injector::*;
 pub use iter::*;
+pub use module::*;
 pub use requests::*;
 pub use services::*;
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -38,7 +38,7 @@ impl Module {
 /// struct Bar();
 /// struct Baz(Vec<Svc<dyn Fooable>>);
 ///
-/// trait Fooable {}
+/// trait Fooable: Send + Sync {}
 /// impl Fooable for Foo {}
 /// impl Fooable for Bar {}
 /// interface! {

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,0 +1,103 @@
+use crate::{Provider, ProviderMap};
+
+/// A collection of providers that can be added all at once to an
+/// [`InjectorBuilder`](crate::InjectorBuilder). Modules can be used to group
+/// together related services and configure the injector in pieces rather than
+/// all at once.
+///
+/// For creating a module easily via a domain specific language, see
+/// [`define_module!`].
+#[derive(Default)]
+pub struct Module {
+    pub(crate) providers: ProviderMap,
+}
+
+impl Module {
+    /// Assigns the provider for a service type. Multiple providers can be
+    /// registered for a service.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn provide<P: Provider>(&mut self, provider: P) {
+        // Should never panic
+        self.providers
+            .entry(provider.result())
+            .or_insert_with(|| Some(Vec::new()))
+            .as_mut()
+            .unwrap()
+            .push(Box::new(provider));
+    }
+}
+
+/// Defines a new module using a domain specific language.
+///
+/// # Example
+///
+/// ```
+/// use runtime_injector::{define_module, interface, IntoSingleton, IntoTransient, Svc, Injector};
+///
+/// struct Foo();
+/// struct Bar();
+/// struct Baz(Vec<Svc<dyn Fooable>>);
+///
+/// trait Fooable {}
+/// impl Fooable for Foo {}
+/// impl Fooable for Bar {}
+/// interface! {
+///     Fooable = [Foo, Bar]
+/// };
+///
+/// let module = define_module! {
+///     services = [
+///         Baz.singleton(),
+///     ],
+///     interfaces = {
+///         dyn Fooable = [
+///             Foo.singleton(),
+///             Bar.singleton(),
+///         ],
+///     },
+/// };
+///
+/// let mut builder = Injector::builder();
+/// builder.add_module(module);
+///
+/// let injector = builder.build();
+/// let baz: Svc<Baz> = injector.get().unwrap();
+/// assert_eq!(2, baz.0.len());
+/// ```
+#[macro_export]
+macro_rules! define_module {
+    {
+        $($key:tt = $value:tt),*
+        $(,)?
+    } => {
+        {
+            #[allow(unused_mut)]
+            let mut module = <$crate::Module as ::std::default::Default>::default();
+            $($crate::define_module!(@provide module, $key = $value);)*
+            module
+        }
+    };
+    (
+        @provide $module:expr,
+        services = [
+            $($service:expr),*
+            $(,)?
+        ]
+    ) => {
+        $($module.provide($service);)*
+    };
+    (
+        @provide $module:expr,
+        interfaces = {
+            $($interface:ty = [
+                $($implementation:expr),*
+                $(,)?
+            ]),*
+            $(,)?
+        }
+    ) => {
+        $(
+            $($module.provide($crate::TypedProvider::with_interface::<$interface>($implementation));)*
+        ),*
+    };
+}

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -55,17 +55,17 @@ impl<T: Service> InterfaceFor<T> for T {}
 ///
 /// // Requests for `dyn Foo` can resolve to either `Bar` or, in a test run,
 /// // `MockBar`. Note that attributes are allowed on each of the listed types.
-/// interface!(
+/// interface! {
 ///     Foo = [
 ///         Bar,
 ///         #[cfg(test)]
 ///         MockBar,
 ///     ]
-/// );
+/// };
 /// ```
 #[macro_export]
 macro_rules! interface {
-    ($trait:tt = [$($(#[$attr:meta])* $impl:ty),* $(,)?]) => {
+    {$trait:tt = [$($(#[$attr:meta])* $impl:ty),* $(,)?]} => {
         impl $crate::Interface for dyn $trait {
             #[allow(unused_assignments)]
             fn downcast(mut service: $crate::DynSvc) -> $crate::InjectResult<$crate::Svc<Self>> {


### PR DESCRIPTION
- Adds modules which are just collections of providers that can be registered all at once in an InjectorBuilder
- Adds a define_module! macro which can be used to easily create those modules

Closes #13 