### PR TITLE
Fallible service factories

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -63,16 +63,16 @@ impl<I: ?Sized + Interface> Services<I> {
     ) -> InjectResult<Self> {
         let service_info = ServiceInfo::of::<I>();
         let providers = provider_map.with_inner_mut(|provider_map| {
-            Ok(provider_map
+            provider_map
                 .get_mut(&service_info)
                 .map(|providers| {
-                    providers.take().ok_or(InjectError::CycleDetected {
+                    providers.take().ok_or_else(|| InjectError::CycleDetected {
                         service_info,
                         cycle: vec![service_info],
                     })
                 })
                 .transpose()?
-                .unwrap_or_else(Vec::new))
+                .ok_or(InjectError::MissingProvider { service_info })
         })?;
 
         Ok(Services {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,14 @@
 //! Custom service providers can also be created by implementing the
 //! [`TypedProvider`] trait.
 //!
+//! # Fallible service factories
+//!
+//! Not all types can always be successfully created. Sometimes, creating an
+//! instance of a service might fail. Rather than panicking on error, it's
+//! possible to instead return a [`Result<T, E>`] from your constructors and
+//! inject the result as a [`Svc<T>`]. Read more in the [docs for
+//! `IntoFallible`](crate::IntoFallible).
+//!
 //! # Example
 //!
 //! ```

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,4 +1,5 @@
 mod constant;
+mod fallible;
 mod func;
 mod interface;
 mod providers;
@@ -7,6 +8,7 @@ mod singleton;
 mod transient;
 
 pub use constant::*;
+pub use fallible::*;
 pub use func::*;
 pub use interface::*;
 pub use providers::*;

--- a/src/services/fallible.rs
+++ b/src/services/fallible.rs
@@ -1,0 +1,107 @@
+use crate::{InjectError, InjectResult, Service, ServiceFactory, ServiceInfo};
+use std::{error::Error, marker::PhantomData};
+
+/// A service factory that may fail during service creation with a custom error
+/// type. During activation failure, an instance of
+/// [`InjectError::ActivationFailed`] is returned as an error.
+pub struct FallibleServiceFactory<D, R, E, F>
+where
+    D: Service,
+    R: Service,
+    E: Service + Error,
+    F: ServiceFactory<D, Result<R, E>>,
+{
+    inner: F,
+    marker: PhantomData<fn(D) -> InjectResult<Result<R, E>>>,
+}
+
+impl<D, R, E, F> ServiceFactory<D, R> for FallibleServiceFactory<D, R, E, F>
+where
+    D: Service,
+    R: Service,
+    E: Service + Error,
+    F: ServiceFactory<D, Result<R, E>>,
+{
+    fn invoke(
+        &mut self,
+        injector: &crate::Injector,
+        request_info: crate::RequestInfo,
+    ) -> InjectResult<R> {
+        let result = self.inner.invoke(injector, request_info)?;
+        match result {
+            Ok(result) => Ok(result),
+            Err(error) => Err(InjectError::ActivationFailed {
+                service_info: ServiceInfo::of::<R>(),
+                inner: Box::new(error),
+            }),
+        }
+    }
+}
+
+/// Defines a conversion into a fallible service factory. This trait is
+/// automatically implemented for all service factories that return a
+/// [`Result<T, E>`] with a type that implements [`Error`] + [`Service`].
+pub trait IntoFallible<D, R, E, F>
+where
+    D: Service,
+    R: Service,
+    E: Service + Error,
+    F: ServiceFactory<D, Result<R, E>>,
+{
+    /// # Example
+    ///
+    /// ```
+    /// use runtime_injector::{
+    ///     InjectError, InjectResult, Injector, IntoFallible, IntoTransient,
+    ///     Svc
+    /// };
+    /// use std::{
+    ///     error::Error,
+    ///     fmt::{Display, Formatter},
+    /// };
+    ///
+    /// #[derive(Debug)]
+    /// struct FooError;
+    ///
+    /// impl Error for FooError {}
+    /// impl Display for FooError {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    ///         write!(f, "An error occurred while creating a Foo")
+    ///     }
+    /// }
+    ///
+    /// struct Foo(Svc<i32>);
+    /// fn make_foo(a: Svc<i32>) -> Result<Foo, FooError> {
+    ///     Err(FooError)
+    /// }
+    ///
+    /// let mut builder = Injector::builder();
+    /// builder.provide(make_foo.fallible().transient());
+    /// builder.provide((|| 0).transient());
+    ///
+    /// let injector = builder.build();
+    /// let foo_result: InjectResult<Svc<Foo>> = injector.get();
+    /// match foo_result {
+    ///     Err(InjectError::ActivationFailed { .. }) => {},
+    ///     Err(error) => Err(error).unwrap(),
+    ///     _ => unreachable!("activation should have failed"),
+    /// }
+    /// ```
+    #[must_use]
+    fn fallible(self) -> FallibleServiceFactory<D, R, E, F>;
+}
+
+impl<D, R, E, F> IntoFallible<D, R, E, F> for F
+where
+    D: Service,
+    R: Service,
+    E: Service + Error,
+    F: ServiceFactory<D, Result<R, E>>,
+{
+    fn fallible(self) -> FallibleServiceFactory<D, R, E, F> {
+        FallibleServiceFactory {
+            inner: self,
+            marker: PhantomData,
+        }
+    }
+}

--- a/src/services/func.rs
+++ b/src/services/func.rs
@@ -1,5 +1,5 @@
 use crate::{
-    InjectResult, Injector, Request, RequestInfo, Service, ServiceInfo, Svc,
+    InjectResult, Injector, Request, RequestInfo, Service, ServiceInfo,
 };
 
 /// A factory for creating instances of a service. All functions of arity 12 or
@@ -31,7 +31,7 @@ where
         &mut self,
         injector: &Injector,
         request_info: RequestInfo,
-    ) -> InjectResult<Svc<R>>;
+    ) -> InjectResult<R>;
 }
 
 macro_rules! impl_provider_function {
@@ -50,7 +50,7 @@ macro_rules! impl_provider_function {
             $($type_name: Request,)*
         {
             #[allow(unused_variables, unused_mut, unused_assignments, non_snake_case)]
-            fn invoke(&mut self, injector: &Injector, request_info: RequestInfo) -> InjectResult<Svc<R>> {
+            fn invoke(&mut self, injector: &Injector, request_info: RequestInfo) -> InjectResult<R> {
                 let request_info = request_info.with_request(ServiceInfo::of::<R>());
                 let result = self($(
                     match <$type_name as Request>::request(&injector, request_info.clone()) {
@@ -64,7 +64,7 @@ macro_rules! impl_provider_function {
                         Err(error) => return Err(error),
                     }
                 ),*);
-                Ok(Svc::new(result))
+                Ok(result)
             }
         }
     };

--- a/src/services/func.rs
+++ b/src/services/func.rs
@@ -21,17 +21,16 @@ use crate::{
 ///
 /// # Type parameters
 /// * `D` - Dependencies of this service as a tuple.
-/// * `R` - Resulting service from invoking this service factory.
-pub trait ServiceFactory<D, R>: 'static
-where
-    R: Service,
-{
+pub trait ServiceFactory<D>: Service {
+    /// The resulting service from invoking this service factory.
+    type Result: Service;
+
     /// Invokes this service factory, creating an instance of the service.
     fn invoke(
         &mut self,
         injector: &Injector,
         request_info: RequestInfo,
-    ) -> InjectResult<R>;
+    ) -> InjectResult<Self::Result>;
 }
 
 macro_rules! impl_provider_function {
@@ -43,14 +42,20 @@ macro_rules! impl_provider_function {
         impl_provider_function!($($rest),*);
     };
     (@impl ($($type_name:ident),*)) => {
-        impl <F, R $(, $type_name)*> ServiceFactory<($($type_name,)*), R> for F
+        impl<F, R $(, $type_name)*> ServiceFactory<($($type_name,)*)> for F
         where
             F: 'static + FnMut($($type_name),*) -> R,
             R: Service,
             $($type_name: Request,)*
         {
+            type Result = F::Output;
+
             #[allow(unused_variables, unused_mut, unused_assignments, non_snake_case)]
-            fn invoke(&mut self, injector: &Injector, request_info: RequestInfo) -> InjectResult<R> {
+            fn invoke(
+                &mut self,
+                injector: &Injector,
+                request_info: RequestInfo
+            ) -> InjectResult<Self::Result> {
                 let request_info = request_info.with_request(ServiceInfo::of::<R>());
                 let result = self($(
                     match <$type_name as Request>::request(&injector, request_info.clone()) {

--- a/src/services/func.rs
+++ b/src/services/func.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::{
     InjectResult, Injector, Request, RequestInfo, Service, ServiceInfo,
 };
@@ -21,7 +23,7 @@ use crate::{
 ///
 /// # Type parameters
 /// * `D` - Dependencies of this service as a tuple.
-pub trait ServiceFactory<D>: Service {
+pub trait ServiceFactory<D>: Any {
     /// The resulting service from invoking this service factory.
     type Result: Service;
 
@@ -44,7 +46,7 @@ macro_rules! impl_provider_function {
     (@impl ($($type_name:ident),*)) => {
         impl<F, R $(, $type_name)*> ServiceFactory<($($type_name,)*)> for F
         where
-            F: 'static + FnMut($($type_name),*) -> R,
+            F: Any + FnMut($($type_name),*) -> R,
             R: Service,
             $($type_name: Request,)*
         {

--- a/src/services/singleton.rs
+++ b/src/services/singleton.rs
@@ -51,6 +51,7 @@ where
         }
 
         let result = self.func.invoke(injector, request_info)?;
+        let result = Svc::new(result);
         self.result = Some(result.clone());
         Ok(result)
     }

--- a/src/services/transient.rs
+++ b/src/services/transient.rs
@@ -10,22 +10,22 @@ use std::marker::PhantomData;
 pub struct TransientProvider<D, R, F>
 where
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, Result = R>,
 {
-    func: F,
+    factory: F,
     marker: PhantomData<fn(D) -> InjectResult<R>>,
 }
 
 impl<D, R, F> TransientProvider<D, R, F>
 where
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, Result = R>,
 {
     /// Creates a new [`TransientProvider`] using a service factory.
     #[must_use]
     pub fn new(func: F) -> Self {
         TransientProvider {
-            func,
+            factory: func,
             marker: PhantomData,
         }
     }
@@ -33,9 +33,9 @@ where
 
 impl<D, R, F> TypedProvider for TransientProvider<D, R, F>
 where
-    D: 'static,
+    D: Service,
     R: Service,
-    F: ServiceFactory<D, R> + Service,
+    F: ServiceFactory<D, Result = R> + Service,
 {
     type Result = R;
 
@@ -44,7 +44,7 @@ where
         injector: &Injector,
         request_info: RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
-        let result = self.func.invoke(injector, request_info)?;
+        let result = self.factory.invoke(injector, request_info)?;
         Ok(Svc::new(result))
     }
 }
@@ -54,7 +54,7 @@ where
 pub trait IntoTransient<D, R, F>
 where
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, Result = R>,
 {
     /// Creates a transient provider. Transient providers create their values
     /// each time the service is requested and will never return service
@@ -84,7 +84,7 @@ where
 impl<D, R, F> IntoTransient<D, R, F> for F
 where
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, Result = R>,
 {
     fn transient(self) -> TransientProvider<D, R, F> {
         TransientProvider::new(self)
@@ -94,7 +94,7 @@ where
 impl<D, R, F> From<F> for TransientProvider<D, R, F>
 where
     R: Service,
-    F: ServiceFactory<D, R>,
+    F: ServiceFactory<D, Result = R>,
 {
     fn from(func: F) -> Self {
         func.transient()

--- a/src/services/transient.rs
+++ b/src/services/transient.rs
@@ -44,7 +44,8 @@ where
         injector: &Injector,
         request_info: RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
-        self.func.invoke(injector, request_info)
+        let result = self.func.invoke(injector, request_info)?;
+        Ok(Svc::new(result))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -241,7 +241,7 @@ fn multi_injection() {
 fn injector_returns_error_on_cycles() {
     struct Foo(Svc<Bar>);
     struct Bar(Svc<Foo>);
-    
+
     let mut builder = Injector::builder();
     builder.provide(Foo.singleton());
     builder.provide(Bar.singleton());


### PR DESCRIPTION
Added fallible service factories. These are chainable off other service factories, allowing custom result types to return activation errors rather than having the result type injected directly. This means that if a factory returns a `Result<Foo, FooError>`, you can now request a `Svc<Foo>` and if `Foo` fails to be constructed and returns an error, then that error will be returned as an activation error (`InjectError::ActivationFailed`) rather than being injected as a `Svc<Result<Foo, FooError>>`.

Closes #15 