### PR TITLE
Owned dependency injection

### DIFF
--- a/crates/runtime_injector/src/any.rs
+++ b/crates/runtime_injector/src/any.rs
@@ -9,7 +9,7 @@ pub trait AsAny: Any {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-impl<T: Any> AsAny for T { 
+impl<T: Any> AsAny for T {
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/runtime_injector/src/injector.rs
+++ b/crates/runtime_injector/src/injector.rs
@@ -144,16 +144,24 @@ impl Injector {
     ///   interface and creates an instance of the service if needed. If
     ///   multiple service providers are registered for that interface, then
     ///   returns an error instead.
-    /// - [`Option<Svc<T>>`]: Requests a service pointer to the given interface
-    ///   and create an instance of the service if needed. If no provider for
-    ///   that service is registered, then returns `Ok(None)` rather than
-    ///   returning an error. If multiple providers are registered, then
-    ///   instead returns an error.
+    /// - [`Box<T>`]: Requests an owned service pointer to the given interface
+    ///   and creates an instance of the service. Not all service providers can
+    ///   provide owned versions of their services, so this may fail for some
+    ///   services.
+    /// - [`Option<Svc<T>>`]/[`Option<Box<T>>`]: Requests a service pointer to
+    ///   the given interface and creates an instance of the service if needed.
+    ///   If no provider for that service is registered, then returns
+    ///   `Ok(None)` rather than returning an error. If multiple providers are
+    ///   registered, then instead returns an error. If an owned pointer is
+    ///   requested but the provider can't provide owned pointers, then returns
+    ///   an error.
+    /// - [`Vec<Svc<T>>`]/[`Vec<Box<T>>`]: Requests all the implementations of
+    ///   an interface. This will eagerly create the services as part of the
+    ///   request. If owned service pointers are requested and any providers
+    ///   can't provide owned pointers, then returns an error instead.
     /// - [`Services<T>`]: Requests all the implementations of an interface.
     ///   This will lazily create the services on demand. See the
     ///   [documentation for `Services<T>`](Services<T>) for more details.
-    /// - [`Vec<Svc<T>>`]: Requests all the implementations of an interface.
-    ///   This will eagerly create the services as part of the request.
     /// - [`Injector`]: Requests a clone of the injector. While it doesn't make
     ///   much sense to request this directly from the injector itself, this
     ///   allows the injector to be requested as a dependency inside of

--- a/crates/runtime_injector/src/lib.rs
+++ b/crates/runtime_injector/src/lib.rs
@@ -60,12 +60,20 @@
 //! inject the result as a [`Svc<T>`]. Read more in the [docs for
 //! `IntoFallible`](crate::IntoFallible).
 //!
+//! # Owned service pointers
+//!
+//! Sometimes, you don't need a reference-counted pointer to your dependency.
+//! If your dependency is a transient service, then it might make more sense
+//! to inject it as a [`Box<T>`] than clone it from a reference-counted service
+//! pointer. In these cases, you can request a [`Box<T>`] directly from the
+//! injector and avoid needing to clone your dependency entirely!
+//!
 //! # Example
 //!
 //! ```
 //! use runtime_injector::{
 //!     define_module, Module, interface, Injector, Svc, IntoSingleton,
-//!     TypedProvider
+//!     TypedProvider, IntoTransient
 //! };
 //! use std::error::Error;
 //!
@@ -146,7 +154,11 @@
 //!             
 //!             // Note that we can register closures as providers as well
 //!             (|_: Svc<dyn DataService>| "Hello, world!").singleton(),
-//!             (|_: Option<Svc<i32>>| 120.9).singleton(),
+//!             (|_: Option<Svc<i32>>| 120.9).transient(),
+//!
+//!             // Since we know our dependency is transient, we can request an
+//!             // owned pointer to it rather than a reference-counted pointer
+//!             (|value: Box<f32>| format!("{}", value)).transient(),
 //!         ],
 //!         interfaces = {
 //!             // Let's choose to use the MockDataService as our data service

--- a/crates/runtime_injector/src/services/service.rs
+++ b/crates/runtime_injector/src/services/service.rs
@@ -51,6 +51,18 @@ feature_unique!(
 
 feature_unique!(
     {
+        /// An owned service pointer holding an instance of `dyn Any`.
+    },
+    {
+        pub type OwnedDynSvc = Box<dyn Any>;
+    },
+    {
+        pub type OwnedDynSvc = Box<dyn Any + Send + Sync>;
+    }
+);
+
+feature_unique!(
+    {
         /// Implemented automatically on types that are capable of being a
         /// service.
     },
@@ -149,6 +161,12 @@ pub enum InjectError {
         providers: usize,
     },
 
+    /// The provider can't provide an owned variant of the requested service.
+    OwnedNotSupported {
+        /// The service that was requested.
+        service_info: ServiceInfo,
+    },
+
     /// An error occurred during activation of a service.
     ActivationFailed {
         /// The service that was requested.
@@ -211,6 +229,13 @@ impl Display for InjectError {
                 "the requested service {} has {} providers registered (did you mean to request a Services<T> instead?)",
                 service_info.name(),
                 providers
+            )?,
+            InjectError::OwnedNotSupported {
+                service_info
+            } => write!(
+                f,
+                "the registered provider can't provide an owned variant of {}",
+                service_info.name()
             )?,
             InjectError::ActivationFailed { service_info, .. } => {
                 write!(f, "an error occurred during activation of {}", service_info.name())?

--- a/crates/runtime_injector/src/services/service.rs
+++ b/crates/runtime_injector/src/services/service.rs
@@ -161,7 +161,8 @@ pub enum InjectError {
         providers: usize,
     },
 
-    /// The provider can't provide an owned variant of the requested service.
+    /// The registered provider can't provide an owned variant of the requested
+    /// service.
     OwnedNotSupported {
         /// The service that was requested.
         service_info: ServiceInfo,

--- a/crates/runtime_injector/src/services/transient.rs
+++ b/crates/runtime_injector/src/services/transient.rs
@@ -47,6 +47,15 @@ where
         let result = self.factory.invoke(injector, request_info)?;
         Ok(Svc::new(result))
     }
+
+    fn provide_owned_typed(
+        &mut self,
+        injector: &Injector,
+        request_info: RequestInfo,
+    ) -> InjectResult<Box<Self::Result>> {
+        let result = self.factory.invoke(injector, request_info)?;
+        Ok(Box::new(result))
+    }
 }
 
 /// Defines a conversion into a transient provider. This trait is automatically

--- a/crates/runtime_injector_actix/src/service.rs
+++ b/crates/runtime_injector_actix/src/service.rs
@@ -64,7 +64,11 @@ impl<R: Request> FromRequest for Injected<R> {
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
         let injector: &Injector = match req.app_data() {
             Some(app_data) => app_data,
-            None => return err(ErrorInternalServerError("no injector is present in app_data")),
+            None => {
+                return err(ErrorInternalServerError(
+                    "no injector is present in app_data",
+                ))
+            }
         };
 
         let inner = match injector.get() {


### PR DESCRIPTION
Allows some services to be injected via `Box<I>` rather than needing to be provided via `Svc<I>`. This allows services to own their dependencies without needing to clone them.

Closes #12 