### PR TITLE
Add support for target-specific arguments

### DIFF
--- a/crates/runtime_injector/src/builder.rs
+++ b/crates/runtime_injector/src/builder.rs
@@ -1,27 +1,58 @@
-use crate::{Injector, Module, Provider, ProviderMap};
+use crate::{
+    Injector, Module, Provider, ProviderMap, RequestInfo, ServiceInfo,
+};
 
 /// A builder for an [`Injector`].
 #[derive(Default)]
 pub struct InjectorBuilder {
     providers: ProviderMap,
+    root_info: RequestInfo,
 }
 
 impl InjectorBuilder {
     /// Assigns the provider for a service type. Multiple providers can be
     /// registered for a service.
-    #[allow(clippy::missing_panics_doc)]
     pub fn provide<P: Provider>(&mut self, provider: P) {
+        self.add_provider(Box::new(provider))
+    }
+
+    /// Adds a provider to the injector.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn add_provider(&mut self, provider: Box<dyn Provider>) {
         // Should never panic
         self.providers
             .entry(provider.result())
             .or_insert_with(|| Some(Vec::new()))
             .as_mut()
             .unwrap()
-            .push(Box::new(provider));
+            .push(provider)
+    }
+
+    /// Removes all providers for a service type.
+    pub fn remove_providers(
+        &mut self,
+        service_info: ServiceInfo,
+    ) -> Option<Vec<Box<dyn Provider>>> {
+        self.providers.remove(&service_info).flatten()
+    }
+
+    /// Borrows the root [`RequestInfo`] that will be used by calls to
+    /// [`Injector::get()`].
+    pub fn root_info(&self) -> &RequestInfo {
+        &self.root_info
+    }
+
+    /// Mutably borrows the root [`RequestInfo`] that will be used by calls to
+    /// [`Injector::get()`].
+    pub fn root_info_mut(&mut self) -> &mut RequestInfo {
+        &mut self.root_info
     }
 
     /// Adds all the providers registered in a module. This may cause multiple
     /// providers to be registered for the same service.
+    ///
+    /// If any conflicting request parameters have been set before adding this
+    /// module, they are overridden.
     #[allow(clippy::missing_panics_doc)]
     pub fn add_module(&mut self, module: Module) {
         for (result, module_providers) in module.providers {
@@ -35,11 +66,15 @@ impl InjectorBuilder {
                 })
                 .or_insert_with(|| Some(module_providers));
         }
+
+        for (key, value) in module.parameters {
+            let _ = self.root_info_mut().insert_parameter_boxed(&key, value);
+        }
     }
 
     /// Builds the injector.
     #[must_use]
     pub fn build(self) -> Injector {
-        Injector::new(self.providers)
+        Injector::new_from_parts(self.providers, self.root_info)
     }
 }

--- a/crates/runtime_injector/src/docs/inversion_of_control.rs
+++ b/crates/runtime_injector/src/docs/inversion_of_control.rs
@@ -147,7 +147,7 @@
 //! multiple target environments! This doesn't even include our business logic.
 //!
 //! ## Simplifying our code with runtime_injector
-//! 
+//!
 //! As our application grows, so does the number of helper functions we need to
 //! create to handle all the different implementations of our services. This
 //! quickly becomes ugly and unmaintainable. What happens if we let something
@@ -158,7 +158,7 @@
 //! ```
 //! use runtime_injector::{
 //!     constant, define_module, interface, Injector, IntoSingleton,
-//!     IntoTransient, Svc, Service
+//!     IntoTransient, Service, Svc,
 //! };
 //!
 //! #[derive(Clone, Debug)]
@@ -292,7 +292,7 @@
 //!     };
 //! }
 //! ```
-//! 
+//!
 //! We still have all our different implementations of `UserDatabase` and
 //! `UserAuthenticator`, but now it's super easy to get the correct
 //! implementations of each of those services when we need to! We don't need

--- a/crates/runtime_injector/src/lib.rs
+++ b/crates/runtime_injector/src/lib.rs
@@ -11,7 +11,7 @@
 //! default-features = false
 //! features = ["rc"]
 //! ```
-//! 
+//!
 //! If you are unfamiliar with dependency injection, then you may want to read
 //! about how a container can help
 //! [simplify your application](crate::docs::inversion_of_control).

--- a/crates/runtime_injector/src/module.rs
+++ b/crates/runtime_injector/src/module.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use crate::{Provider, ProviderMap, RequestParameter};
+use std::collections::HashMap;
 
 /// A collection of providers that can be added all at once to an
 /// [`InjectorBuilder`](crate::InjectorBuilder). Modules can be used to group

--- a/crates/runtime_injector/src/requests.rs
+++ b/crates/runtime_injector/src/requests.rs
@@ -1,7 +1,9 @@
+mod arg;
 mod info;
 mod parameter;
 mod request;
 
+pub use arg::*;
 pub use info::*;
 pub use parameter::*;
 pub use request::*;

--- a/crates/runtime_injector/src/requests/arg.rs
+++ b/crates/runtime_injector/src/requests/arg.rs
@@ -25,9 +25,9 @@ use std::{
 /// let foo: Box<Foo> = injector.get().unwrap();
 /// assert_eq!(12, *foo.0);
 /// ```
-pub struct Arg<T: Service + AsAny + Clone + Debug>(T);
+pub struct Arg<T: Service + AsAny + Clone>(T);
 
-impl<T: Service + AsAny + Clone + Debug> Arg<T> {
+impl<T: Service + AsAny + Clone> Arg<T> {
     pub(crate) fn param_name(target: ServiceInfo) -> String {
         format!(
             "runtime_injector::Arg[target={:?},type={:?}]",
@@ -42,7 +42,7 @@ impl<T: Service + AsAny + Clone + Debug> Arg<T> {
     }
 }
 
-impl<T: Service + AsAny + Clone + Debug> Deref for Arg<T> {
+impl<T: Service + AsAny + Clone> Deref for Arg<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -50,13 +50,13 @@ impl<T: Service + AsAny + Clone + Debug> Deref for Arg<T> {
     }
 }
 
-impl<T: Service + AsAny + Clone + Debug> DerefMut for Arg<T> {
+impl<T: Service + AsAny + Clone> DerefMut for Arg<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<T: Service + AsAny + Clone + Debug> Request for Arg<T> {
+impl<T: Service + AsAny + Clone> Request for Arg<T> {
     fn request(_injector: &Injector, info: RequestInfo) -> InjectResult<Self> {
         let parent_request = info.service_path().last().ok_or_else(|| {
             InjectError::ActivationFailed {
@@ -116,14 +116,14 @@ impl Display for ArgRequestError {
 /// Allows defining pre-defined arguments to services.
 pub trait WithArg {
     /// Adds an argument for a service. See the docs for [`Arg<T>`].
-    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+    fn with_arg<S: Service, T: Service + AsAny + Clone>(
         &mut self,
         value: T,
     ) -> Option<Box<dyn RequestParameter>>;
 }
 
 impl WithArg for RequestInfo {
-    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+    fn with_arg<S: Service, T: Service + AsAny + Clone>(
         &mut self,
         value: T,
     ) -> Option<Box<dyn RequestParameter>> {
@@ -135,7 +135,7 @@ impl WithArg for RequestInfo {
 }
 
 impl WithArg for InjectorBuilder {
-    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+    fn with_arg<S: Service, T: Service + AsAny + Clone>(
         &mut self,
         value: T,
     ) -> Option<Box<dyn RequestParameter>> {
@@ -144,7 +144,7 @@ impl WithArg for InjectorBuilder {
 }
 
 impl WithArg for Module {
-    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+    fn with_arg<S: Service, T: Service + AsAny + Clone>(
         &mut self,
         value: T,
     ) -> Option<Box<dyn RequestParameter>> {

--- a/crates/runtime_injector/src/requests/arg.rs
+++ b/crates/runtime_injector/src/requests/arg.rs
@@ -1,0 +1,156 @@
+use crate::{
+    AsAny, InjectError, InjectResult, Injector, InjectorBuilder, Module,
+    Request, RequestInfo, RequestParameter, Service, ServiceInfo,
+};
+use std::{
+    error::Error,
+    fmt::{Debug, Display, Formatter},
+    ops::{Deref, DerefMut},
+};
+
+/// Allows custom pre-defined values to be passed as arguments to services.
+///
+/// # Example
+///
+/// ```
+/// use runtime_injector::{Arg, Injector, IntoTransient, WithArg};
+///
+/// struct Foo(Arg<i32>);
+///
+/// let mut builder = Injector::builder();
+/// builder.provide(Foo.transient());
+/// builder.with_arg::<Foo, i32>(12);
+///
+/// let injector = builder.build();
+/// let foo: Box<Foo> = injector.get().unwrap();
+/// assert_eq!(12, *foo.0);
+/// ```
+pub struct Arg<T: Service + AsAny + Clone + Debug>(T);
+
+impl<T: Service + AsAny + Clone + Debug> Arg<T> {
+    pub(crate) fn param_name(target: ServiceInfo) -> String {
+        format!(
+            "runtime_injector::Arg[target={:?},type={:?}]",
+            target.name(),
+            ServiceInfo::of::<T>().name()
+        )
+    }
+
+    /// Converts an argument into its inner value.
+    pub fn into_inner(arg: Self) -> T {
+        arg.0
+    }
+}
+
+impl<T: Service + AsAny + Clone + Debug> Deref for Arg<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Service + AsAny + Clone + Debug> DerefMut for Arg<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Service + AsAny + Clone + Debug> Request for Arg<T> {
+    fn request(_injector: &Injector, info: RequestInfo) -> InjectResult<Self> {
+        let parent_request = info.service_path().last().ok_or_else(|| {
+            InjectError::ActivationFailed {
+                service_info: ServiceInfo::of::<Self>(),
+                inner: Box::new(ArgRequestError::NoParentRequest),
+            }
+        })?;
+
+        let request_name = Self::param_name(*parent_request);
+        let param = info.get_parameter(&request_name).ok_or_else(|| {
+            InjectError::ActivationFailed {
+                service_info: ServiceInfo::of::<Self>(),
+                inner: Box::new(ArgRequestError::NoParentRequest),
+            }
+        })?;
+
+        let param: &T = param.downcast_ref().ok_or_else(|| {
+            InjectError::ActivationFailed {
+                service_info: ServiceInfo::of::<Self>(),
+                inner: Box::new(ArgRequestError::ParameterTypeInvalid),
+            }
+        })?;
+
+        Ok(Arg(param.clone()))
+    }
+}
+
+/// An error occurred while injecting an instance of [`Arg<T>`].
+#[derive(Debug)]
+pub enum ArgRequestError {
+    /// The argument value was not provided.
+    MissingParameter,
+    /// The argument value is the wrong type.
+    ParameterTypeInvalid,
+    /// There is no parent request.
+    NoParentRequest,
+}
+
+impl Error for ArgRequestError {}
+
+impl Display for ArgRequestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArgRequestError::MissingParameter => {
+                write!(f, "no value assigned for this argument")
+            }
+            ArgRequestError::ParameterTypeInvalid => {
+                write!(f, "argument value is the wrong type")
+            }
+            ArgRequestError::NoParentRequest => {
+                write!(f, "no parent request was found")
+            }
+        }
+    }
+}
+
+/// Allows defining pre-defined arguments to services.
+pub trait WithArg {
+    /// Adds an argument for a service. See the docs for [`Arg<T>`].
+    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+        &mut self,
+        value: T,
+    ) -> Option<Box<dyn RequestParameter>>;
+}
+
+impl WithArg for RequestInfo {
+    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+        &mut self,
+        value: T,
+    ) -> Option<Box<dyn RequestParameter>> {
+        self.insert_parameter(
+            &Arg::<T>::param_name(ServiceInfo::of::<S>()),
+            value,
+        )
+    }
+}
+
+impl WithArg for InjectorBuilder {
+    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+        &mut self,
+        value: T,
+    ) -> Option<Box<dyn RequestParameter>> {
+        self.root_info_mut().with_arg::<S, T>(value)
+    }
+}
+
+impl WithArg for Module {
+    fn with_arg<S: Service, T: Service + AsAny + Clone + Debug>(
+        &mut self,
+        value: T,
+    ) -> Option<Box<dyn RequestParameter>> {
+        self.insert_parameter(
+            &Arg::<T>::param_name(ServiceInfo::of::<S>()),
+            value,
+        )
+    }
+}

--- a/crates/runtime_injector/src/requests/info.rs
+++ b/crates/runtime_injector/src/requests/info.rs
@@ -73,14 +73,22 @@ impl RequestInfo {
         &self.service_path
     }
 
-    /// Sets the value request parameter for the request. If a parameter has
-    /// already been set to a value, then that value is returned.
+    /// Sets the value of a request parameter for the request. If a parameter
+    /// has already been set to a value, then that value is returned.
     pub fn insert_parameter(
         &mut self,
         key: &str,
         value: impl RequestParameter,
     ) -> Option<Box<dyn RequestParameter>> {
-        self.parameters.insert(key.to_owned(), Box::new(value))
+        self.insert_parameter_boxed(key, Box::new(value))
+    }
+
+    pub(crate) fn insert_parameter_boxed(
+        &mut self,
+        key: &str,
+        value: Box<dyn RequestParameter>,
+    ) -> Option<Box<dyn RequestParameter>> {
+        self.parameters.insert(key.to_owned(), value)
     }
 
     /// Removes and returns the value of a parameter if it has been set.

--- a/crates/runtime_injector/src/requests/info.rs
+++ b/crates/runtime_injector/src/requests/info.rs
@@ -1,8 +1,11 @@
 use crate::{RequestParameter, ServiceInfo};
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+};
 
 /// Information about an active request.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct RequestInfo {
     service_path: Vec<ServiceInfo>,
     parameters: HashMap<String, Box<dyn RequestParameter>>,
@@ -118,5 +121,14 @@ impl RequestInfo {
 impl Default for RequestInfo {
     fn default() -> Self {
         RequestInfo::new()
+    }
+}
+
+impl Debug for RequestInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // TODO: maybe use finish_non_exhaustive when 1.53 hits stable
+        f.debug_struct("RequestInfo")
+            .field("service_path", &self.service_path)
+            .finish()
     }
 }

--- a/crates/runtime_injector/src/requests/parameter.rs
+++ b/crates/runtime_injector/src/requests/parameter.rs
@@ -1,13 +1,12 @@
 use crate::{AsAny, Service};
-use std::fmt::Debug;
 
 /// A parameter for configuring requested services.
-pub trait RequestParameter: Service + Debug + AsAny {
+pub trait RequestParameter: Service + AsAny {
     /// Clones this parameter into a boxed trait object.
     fn clone_dyn(&self) -> Box<dyn RequestParameter>;
 }
 
-impl<T: Service + Debug + Clone + AsAny> RequestParameter for T {
+impl<T: Service + Clone + AsAny> RequestParameter for T {
     fn clone_dyn(&self) -> Box<dyn RequestParameter> {
         Box::new(self.clone())
     }


### PR DESCRIPTION
Adds support for injecting target-specific arguments to configure how services are created. Also updates the `define_module!` macro to make it easier to specify those arguments.

Closes #23 