### PR TITLE
Change 'interface!' macro to use 'dyn Trait' like the rest of library

### DIFF
--- a/crates/runtime_injector/Cargo.toml
+++ b/crates/runtime_injector/Cargo.toml
@@ -1,11 +1,8 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "runtime_injector"
 version = "0.4.0"
 authors = ["TehPers <tehperz@gmail.com>"]
-edition = "2021"
-# edition = "2018"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Runtime dependency injection container"
 repository = "https://github.com/TehPers/runtime_injector"

--- a/crates/runtime_injector/src/docs/inversion_of_control.rs
+++ b/crates/runtime_injector/src/docs/inversion_of_control.rs
@@ -216,24 +216,23 @@
 //!     }
 //! }
 //!
-//! // Now we need to declare what services we can use. Since we have three
-//! // implementations of a user database, we'll declare `UserDatabase` as
-//! // being an interface that supports those three types
+//! // Now we need to declare what services we can use.
 //! interface! {
+//!     // Since we have three implementations of a user database, we'll
+//!     // declare `UserDatabase` as being an interface that supports those
+//!     // three types
 //!     dyn UserDatabase = [
 //!         MockUserDatabase,
 //!         SqlUserDatabase,
 //!         IntegrationUserDatabase,
-//!     ]
-//! }
+//!     ],
 //!
-//! // Similarly, we'll declare `UserAuthenticator` as being an interface that
-//! // supports both our database-backed authenticator and our mock one
-//! interface! {
+//!     // Similarly, we'll declare `UserAuthenticator` as being an interface
+//!     // that supports both our database-backed authenticator and mock one
 //!     dyn UserAuthenticator = [
 //!         MockUserAuthenticator,
 //!         DatabaseUserAuthenticator,
-//!     ]
+//!     ],
 //! }
 //!
 //! fn main() {

--- a/crates/runtime_injector/src/docs/inversion_of_control.rs
+++ b/crates/runtime_injector/src/docs/inversion_of_control.rs
@@ -220,7 +220,7 @@
 //! // implementations of a user database, we'll declare `UserDatabase` as
 //! // being an interface that supports those three types
 //! interface! {
-//!     UserDatabase = [
+//!     dyn UserDatabase = [
 //!         MockUserDatabase,
 //!         SqlUserDatabase,
 //!         IntegrationUserDatabase,
@@ -230,7 +230,7 @@
 //! // Similarly, we'll declare `UserAuthenticator` as being an interface that
 //! // supports both our database-backed authenticator and our mock one
 //! interface! {
-//!     UserAuthenticator = [
+//!     dyn UserAuthenticator = [
 //!         MockUserAuthenticator,
 //!         DatabaseUserAuthenticator,
 //!     ]

--- a/crates/runtime_injector/src/injector.rs
+++ b/crates/runtime_injector/src/injector.rs
@@ -204,7 +204,7 @@ impl Injector {
     /// };
     ///
     /// trait Foo: Send + Sync {}
-    /// interface!(Foo = [Bar]);
+    /// interface!(dyn Foo = [Bar]);
     ///
     /// #[derive(Default)]
     /// struct Bar;
@@ -226,7 +226,7 @@ impl Injector {
     /// };
     ///
     /// trait Foo: Send + Sync {}
-    /// interface!(Foo = [Bar, Baz]);
+    /// interface!(dyn Foo = [Bar, Baz]);
     ///
     /// #[derive(Default)]
     /// struct Bar;

--- a/crates/runtime_injector/src/iter.rs
+++ b/crates/runtime_injector/src/iter.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 ///     fn baz(&self) {}
 /// }
 ///
-/// interface!(Fooable = [Foo, Bar]);
+/// interface!(dyn Fooable = [Foo, Bar]);
 ///
 /// #[derive(Default)]
 /// struct Foo;

--- a/crates/runtime_injector/src/lib.rs
+++ b/crates/runtime_injector/src/lib.rs
@@ -114,7 +114,7 @@
 //! // Specify which types implement the DataService interface. This does not
 //! // determine the actual implementation used. It only registers the types as
 //! // possible implementations of the DataService interface.
-//! interface!(DataService = [SqlDataService, MockDataService]);
+//! interface!(dyn DataService = [SqlDataService, MockDataService]);
 //!
 //! // Here's another service our application uses. This service depends on our
 //! // data service, however it doesn't care how that service is actually

--- a/crates/runtime_injector/src/module.rs
+++ b/crates/runtime_injector/src/module.rs
@@ -46,7 +46,7 @@ impl Module {
 /// impl Fooable for Foo {}
 /// impl Fooable for Bar {}
 /// interface! {
-///     Fooable = [
+///     dyn Fooable = [
 ///         Foo,
 ///         Bar,
 ///         #[cfg(test)]

--- a/crates/runtime_injector/src/services/interface.rs
+++ b/crates/runtime_injector/src/services/interface.rs
@@ -69,7 +69,7 @@ impl<T: Service> InterfaceFor<T> for T {}
 /// // Requests for `dyn Foo` can resolve to either `Bar` or, in a test run,
 /// // `MockBar`. Note that attributes are allowed on each of the listed types.
 /// interface! {
-///     Foo = [
+///     dyn Foo = [
 ///         Bar,
 ///         #[cfg(test)]
 ///         MockBar,
@@ -78,8 +78,8 @@ impl<T: Service> InterfaceFor<T> for T {}
 /// ```
 #[macro_export]
 macro_rules! interface {
-    {$trait:tt = [$($(#[$attr:meta])* $impl:ty),* $(,)?]} => {
-        impl $crate::Interface for dyn $trait {
+    {$interface:ty = [$($(#[$attr:meta])* $impl:ty),* $(,)?]} => {
+        impl $crate::Interface for $interface {
             #[allow(unused_assignments)]
             fn downcast(mut service: $crate::DynSvc) -> $crate::InjectResult<$crate::Svc<Self>> {
                 $(
@@ -109,7 +109,7 @@ macro_rules! interface {
 
         $(
             $(#[$attr])*
-            impl $crate::InterfaceFor<$impl> for dyn $trait {}
+            impl $crate::InterfaceFor<$impl> for $interface {}
         )*
     };
 }

--- a/crates/runtime_injector/src/services/interface.rs
+++ b/crates/runtime_injector/src/services/interface.rs
@@ -73,43 +73,53 @@ impl<T: Service> InterfaceFor<T> for T {}
 ///         Bar,
 ///         #[cfg(test)]
 ///         MockBar,
-///     ]
+///     ],
 /// };
 /// ```
 #[macro_export]
 macro_rules! interface {
-    {$interface:ty = [$($(#[$attr:meta])* $impl:ty),* $(,)?]} => {
-        impl $crate::Interface for $interface {
-            #[allow(unused_assignments)]
-            fn downcast(mut service: $crate::DynSvc) -> $crate::InjectResult<$crate::Svc<Self>> {
-                $(
-                    $(#[$attr])*
-                    match service.downcast::<$impl>() {
-                        Ok(downcasted) => return Ok(downcasted as $crate::Svc<Self>),
-                        Err(input) => service = input,
-                    }
-                )*
-
-                Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
-            }
-
-            #[allow(unused_assignments)]
-            fn downcast_owned(mut service: $crate::OwnedDynSvc) -> $crate::InjectResult<::std::boxed::Box<Self>> {
-                $(
-                    $(#[$attr])*
-                    match service.downcast::<$impl>() {
-                        Ok(downcasted) => return Ok(downcasted as ::std::boxed::Box<Self>),
-                        Err(input) => service = input,
-                    }
-                )*
-
-                Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
-            }
-        }
-
+    {
         $(
-            $(#[$attr])*
-            impl $crate::InterfaceFor<$impl> for $interface {}
+            $interface:ty = [
+                $($(#[$attr:meta])* $impl:ty),*
+                $(,)?
+            ]
+        ),*
+        $(,)?
+    } => {
+        $(
+            impl $crate::Interface for $interface {
+                #[allow(unused_assignments)]
+                fn downcast(mut service: $crate::DynSvc) -> $crate::InjectResult<$crate::Svc<Self>> {
+                    $(
+                        $(#[$attr])*
+                        match service.downcast::<$impl>() {
+                            Ok(downcasted) => return Ok(downcasted as $crate::Svc<Self>),
+                            Err(input) => service = input,
+                        }
+                    )*
+
+                    Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
+                }
+
+                #[allow(unused_assignments)]
+                fn downcast_owned(mut service: $crate::OwnedDynSvc) -> $crate::InjectResult<::std::boxed::Box<Self>> {
+                    $(
+                        $(#[$attr])*
+                        match service.downcast::<$impl>() {
+                            Ok(downcasted) => return Ok(downcasted as ::std::boxed::Box<Self>),
+                            Err(input) => service = input,
+                        }
+                    )*
+
+                    Err($crate::InjectError::MissingProvider { service_info: $crate::ServiceInfo::of::<Self>() })
+                }
+            }
+
+            $(
+                $(#[$attr])*
+                impl $crate::InterfaceFor<$impl> for $interface {}
+            )*
         )*
     };
 }

--- a/crates/runtime_injector/src/services/providers.rs
+++ b/crates/runtime_injector/src/services/providers.rs
@@ -131,7 +131,7 @@ pub trait TypedProvider: Sized + Provider {
     ///     fn bar(&self) {}
     /// }
     ///
-    /// interface!(Fooable = [Foo]);
+    /// interface!(dyn Fooable = [Foo]);
     ///
     /// #[derive(Default)]
     /// struct Foo;

--- a/crates/runtime_injector/src/tests.rs
+++ b/crates/runtime_injector/src/tests.rs
@@ -149,7 +149,7 @@ fn interfaces() {
     }
 
     interface!(
-        Foo = [
+        dyn Foo = [
             Svc1,
             #[cfg(test)]
             Svc2,
@@ -223,7 +223,7 @@ fn multi_injection() {
     impl Foo for Svc2 {}
     impl Foo for Svc3 {}
 
-    interface!(Foo = [Svc1, Svc2, Svc3]);
+    interface!(dyn Foo = [Svc1, Svc2, Svc3]);
 
     let mut builder = Injector::builder();
     builder.provide(Svc1::default.transient().with_interface::<dyn Foo>());


### PR DESCRIPTION
Changes `interface!` macro to require `dyn Trait = [...]` instead of just `Trait = [...]`. This makes the macro work more similarly to other parts of the library, like `define_module!` which needs `dyn Trait = [...]` when defining providers for an interface, and `Svc<dyn Trait>`/`Services<dyn Trait>`/etc when requesting an instance of the interface.

Also adds support for trailing commas and multiple interface definitions in the same `interface!` block.

While this is technically a non-breaking change (trait objects don't currently *need* an explicit `dyn` to compile), it adds a bunch of extra warnings to existing code, so this change will wait until 0.4.