### PR TITLE
Cleanup existing code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,3 @@ jobs:
           --tests
           --no-default-features
           --features ${{ matrix.features }}
-          --
-          -D clippy::all
-          -D clippy::pedantic

--- a/crates/runtime_injector/Cargo.toml
+++ b/crates/runtime_injector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_injector"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["TehPers <tehperz@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/runtime_injector/src/builder.rs
+++ b/crates/runtime_injector/src/builder.rs
@@ -38,12 +38,14 @@ impl InjectorBuilder {
 
     /// Borrows the root [`RequestInfo`] that will be used by calls to
     /// [`Injector::get()`].
+    #[must_use]
     pub fn root_info(&self) -> &RequestInfo {
         &self.root_info
     }
 
     /// Mutably borrows the root [`RequestInfo`] that will be used by calls to
     /// [`Injector::get()`].
+    #[must_use]
     pub fn root_info_mut(&mut self) -> &mut RequestInfo {
         &mut self.root_info
     }
@@ -68,7 +70,7 @@ impl InjectorBuilder {
         }
 
         for (key, value) in module.parameters {
-            let _ = self.root_info_mut().insert_parameter_boxed(&key, value);
+            drop(self.root_info_mut().insert_parameter_boxed(&key, value));
         }
     }
 

--- a/crates/runtime_injector/src/injector.rs
+++ b/crates/runtime_injector/src/injector.rs
@@ -334,7 +334,7 @@ mod tests {
                 _injector: &Injector,
                 _request_info: &RequestInfo,
             ) -> InjectResult<DynSvc> {
-                Ok(Svc::new(1.2f32))
+                Ok(Svc::new(1.2_f32))
             }
         }
 

--- a/crates/runtime_injector/src/injector.rs
+++ b/crates/runtime_injector/src/injector.rs
@@ -257,7 +257,7 @@ impl Injector {
     /// assert!(injector.get::<Svc<dyn Foo>>().is_err());
     /// ```
     pub fn get<R: Request>(&self) -> InjectResult<R> {
-        self.get_with(self.root_request_info.as_ref().clone())
+        self.get_with(self.root_request_info.as_ref())
     }
 
     /// Performs a request for a service with additional request information.
@@ -294,7 +294,7 @@ impl Injector {
     /// ```
     pub fn get_with<R: Request>(
         &self,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<R> {
         R::request(self, request_info)
     }
@@ -303,9 +303,13 @@ impl Injector {
     /// equivalent to requesting [`Services<T>`] from [`Injector::get()`].
     pub(crate) fn get_service<I: ?Sized + Interface>(
         &self,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Services<I>> {
-        Services::new(self.clone(), self.provider_map.clone(), request_info)
+        Services::new(
+            self.clone(),
+            self.provider_map.clone(),
+            request_info.clone(),
+        )
     }
 }
 
@@ -328,7 +332,7 @@ mod tests {
             fn provide(
                 &mut self,
                 _injector: &Injector,
-                _request_info: RequestInfo,
+                _request_info: &RequestInfo,
             ) -> InjectResult<DynSvc> {
                 Ok(Svc::new(1.2f32))
             }

--- a/crates/runtime_injector/src/injector.rs
+++ b/crates/runtime_injector/src/injector.rs
@@ -289,7 +289,7 @@ impl Injector {
     /// let mut request_info = RequestInfo::default();
     /// request_info.insert_parameter("value", "foo".to_owned());
     ///
-    /// let foo: Svc<Foo> = injector.get_with(request_info).unwrap();
+    /// let foo: Svc<Foo> = injector.get_with(&request_info).unwrap();
     /// assert_eq!("foo", foo.0);
     /// ```
     pub fn get_with<R: Request>(

--- a/crates/runtime_injector/src/iter.rs
+++ b/crates/runtime_injector/src/iter.rs
@@ -222,7 +222,7 @@ impl<'a, I: ?Sized + Interface> Iterator for ServicesIter<'a, I> {
             Some(provider) => {
                 self.index += 1;
                 let result = match provider
-                    .provide(self.injector, self.request_info.clone())
+                    .provide(self.injector, self.request_info)
                 {
                     Ok(result) => I::downcast(result),
                     Err(InjectError::CycleDetected { mut cycle, .. }) => {
@@ -290,7 +290,7 @@ impl<'a, I: ?Sized + Interface> Iterator for OwnedServicesIter<'a, I> {
             Some(provider) => {
                 self.index += 1;
                 let result = match provider
-                    .provide_owned(self.injector, self.request_info.clone())
+                    .provide_owned(self.injector, self.request_info)
                 {
                     Ok(result) => I::downcast_owned(result),
                     Err(InjectError::CycleDetected { mut cycle, .. }) => {

--- a/crates/runtime_injector/src/lib.rs
+++ b/crates/runtime_injector/src/lib.rs
@@ -236,7 +236,8 @@
     clippy::module_name_repetitions,
     clippy::missing_errors_doc,
     clippy::doc_markdown,
-    clippy::needless_doctest_main
+    clippy::needless_doctest_main,
+    clippy::needless_pass_by_value
 )]
 
 #[cfg(not(any(feature = "arc", feature = "rc")))]

--- a/crates/runtime_injector/src/lib.rs
+++ b/crates/runtime_injector/src/lib.rs
@@ -230,11 +230,13 @@
 //! ```
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs, clippy::all, clippy::pedantic)]
+#![deny(clippy::all, clippy::pedantic)]
+#![warn(missing_docs)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::missing_errors_doc,
-    clippy::needless_pass_by_value
+    clippy::doc_markdown,
+    clippy::needless_doctest_main
 )]
 
 #[cfg(not(any(feature = "arc", feature = "rc")))]

--- a/crates/runtime_injector/src/requests.rs
+++ b/crates/runtime_injector/src/requests.rs
@@ -1,11 +1,11 @@
 mod arg;
-mod info;
 mod factory;
+mod info;
 mod parameter;
 mod request;
 
 pub use arg::*;
-pub use info::*;
 pub use factory::*;
+pub use info::*;
 pub use parameter::*;
 pub use request::*;

--- a/crates/runtime_injector/src/requests/arg.rs
+++ b/crates/runtime_injector/src/requests/arg.rs
@@ -185,7 +185,7 @@ mod tests {
                     inner.downcast_ref().expect("failed to downcast error");
                 match inner {
                     ArgRequestError::MissingParameter => {}
-                    inner @ _ => Err(inner).unwrap(),
+                    inner => Err(inner).unwrap(),
                 }
             }
             Err(error) => Err(error).unwrap(),
@@ -207,7 +207,7 @@ mod tests {
                     inner.downcast_ref().expect("failed to downcast error");
                 match inner {
                     ArgRequestError::NoParentRequest => {}
-                    inner @ _ => Err(inner).unwrap(),
+                    inner => Err(inner).unwrap(),
                 }
             }
             Err(error) => Err(error).unwrap(),

--- a/crates/runtime_injector/src/requests/arg.rs
+++ b/crates/runtime_injector/src/requests/arg.rs
@@ -57,7 +57,7 @@ impl<T: Service + AsAny + Clone> DerefMut for Arg<T> {
 }
 
 impl<T: Service + AsAny + Clone> Request for Arg<T> {
-    fn request(_injector: &Injector, info: RequestInfo) -> InjectResult<Self> {
+    fn request(_injector: &Injector, info: &RequestInfo) -> InjectResult<Self> {
         let parent_request = info.service_path().last().ok_or_else(|| {
             InjectError::ActivationFailed {
                 service_info: ServiceInfo::of::<Self>(),

--- a/crates/runtime_injector/src/requests/arg.rs
+++ b/crates/runtime_injector/src/requests/arg.rs
@@ -56,6 +56,7 @@ impl<T: Service + AsAny + Clone> DerefMut for Arg<T> {
     }
 }
 
+/// Allows custom pre-defined values to be passed as arguments to services.
 impl<T: Service + AsAny + Clone> Request for Arg<T> {
     fn request(_injector: &Injector, info: &RequestInfo) -> InjectResult<Self> {
         let parent_request = info.service_path().last().ok_or_else(|| {

--- a/crates/runtime_injector/src/requests/factory.rs
+++ b/crates/runtime_injector/src/requests/factory.rs
@@ -57,6 +57,7 @@ impl<R: Request> Factory<R> {
 
     /// Gets this factory's inner [`RequestInfo`]. This request info is used by
     /// all requests the factory makes.
+    #[must_use]
     pub fn request_info(&self) -> &RequestInfo {
         &self.request_info
     }
@@ -101,6 +102,7 @@ impl<R: Request> Factory<R> {
     /// assert_eq!(1, *foo1.0);
     /// assert_eq!(2, *foo2.0);
     /// ```
+    #[must_use]
     pub fn request_info_mut(&mut self) -> &mut RequestInfo {
         &mut self.request_info
     }

--- a/crates/runtime_injector/src/requests/factory.rs
+++ b/crates/runtime_injector/src/requests/factory.rs
@@ -33,11 +33,20 @@ use std::marker::PhantomData;
 /// let _foo2 = bar.0.get().unwrap();
 /// // ...
 /// ```
-#[derive(Clone)]
 pub struct Factory<R: Request> {
     injector: Injector,
     request_info: RequestInfo,
     marker: PhantomData<fn(&Injector, RequestInfo) -> R>,
+}
+
+impl<R: Request> Clone for Factory<R> {
+    fn clone(&self) -> Self {
+        Factory {
+            injector: self.injector.clone(),
+            request_info: self.request_info.clone(),
+            marker: PhantomData,
+        }
+    }
 }
 
 impl<R: Request> Factory<R> {
@@ -60,6 +69,33 @@ impl<R: Request> Factory<R> {
     /// being executed. Since the factory can be cloned, requests can be
     /// specialized by first cloning the factory, then modifying the
     /// [`RequestInfo`] on the clone and using it to make the request instead.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use runtime_injector::{Arg, Factory, Injector, IntoTransient, WithArg};
+    ///
+    /// struct Foo(Arg<i32>);
+    ///
+    /// let mut builder = Injector::builder();
+    /// builder.provide(Foo.transient());
+    ///
+    /// let injector = builder.build();
+    /// let factory: Factory<Box<Foo>> = injector.get().unwrap();
+    /// let foo1 = {
+    ///     let mut factory = factory.clone();
+    ///     factory.request_info_mut().with_arg::<Foo, i32>(1);
+    ///     factory.get().unwrap()
+    /// };
+    /// let foo2 = {
+    ///     let mut factory = factory.clone();
+    ///     factory.request_info_mut().with_arg::<Foo, i32>(2);
+    ///     factory.get().unwrap()
+    /// };
+    ///
+    /// assert_eq!(1, *foo1.0);
+    /// assert_eq!(2, *foo2.0);
+    /// ```
     pub fn request_info_mut(&mut self) -> &mut RequestInfo {
         &mut self.request_info
     }

--- a/crates/runtime_injector/src/requests/factory.rs
+++ b/crates/runtime_injector/src/requests/factory.rs
@@ -73,25 +73,30 @@ impl<R: Request> Factory<R> {
     /// ## Example
     ///
     /// ```
-    /// use runtime_injector::{Arg, Factory, Injector, IntoTransient, WithArg};
+    /// use runtime_injector::{
+    ///     Arg, Factory, InjectResult, Injector, IntoSingleton, IntoTransient,
+    ///     Svc, WithArg,
+    /// };
     ///
     /// struct Foo(Arg<i32>);
     ///
+    /// struct Bar(Factory<Box<Foo>>);
+    /// impl Bar {
+    ///     fn get_foo(&self, arg: i32) -> InjectResult<Box<Foo>> {
+    ///         let mut factory = self.0.clone();
+    ///         factory.request_info_mut().with_arg::<Foo, i32>(arg);
+    ///         factory.get()
+    ///     }
+    /// }
+    ///
     /// let mut builder = Injector::builder();
     /// builder.provide(Foo.transient());
+    /// builder.provide(Bar.singleton());
     ///
     /// let injector = builder.build();
-    /// let factory: Factory<Box<Foo>> = injector.get().unwrap();
-    /// let foo1 = {
-    ///     let mut factory = factory.clone();
-    ///     factory.request_info_mut().with_arg::<Foo, i32>(1);
-    ///     factory.get().unwrap()
-    /// };
-    /// let foo2 = {
-    ///     let mut factory = factory.clone();
-    ///     factory.request_info_mut().with_arg::<Foo, i32>(2);
-    ///     factory.get().unwrap()
-    /// };
+    /// let bar: Svc<Bar> = injector.get().unwrap();
+    /// let foo1 = bar.get_foo(1).unwrap();
+    /// let foo2 = bar.get_foo(2).unwrap();
     ///
     /// assert_eq!(1, *foo1.0);
     /// assert_eq!(2, *foo2.0);

--- a/crates/runtime_injector/src/requests/factory.rs
+++ b/crates/runtime_injector/src/requests/factory.rs
@@ -108,6 +108,8 @@ impl<R: Request> Factory<R> {
     }
 }
 
+/// Lazy request factory allowing requests to be made outside of service
+/// creation.
 impl<R: Request> Request for Factory<R> {
     fn request(injector: &Injector, info: &RequestInfo) -> InjectResult<Self> {
         Ok(Factory {

--- a/crates/runtime_injector/src/requests/factory.rs
+++ b/crates/runtime_injector/src/requests/factory.rs
@@ -43,7 +43,7 @@ pub struct Factory<R: Request> {
 impl<R: Request> Factory<R> {
     /// Performs the factory's inner request.
     pub fn get(&self) -> InjectResult<R> {
-        R::request(&self.injector, self.request_info.clone())
+        R::request(&self.injector, &self.request_info)
     }
 
     /// Gets this factory's inner [`RequestInfo`]. This request info is used by
@@ -66,10 +66,10 @@ impl<R: Request> Factory<R> {
 }
 
 impl<R: Request> Request for Factory<R> {
-    fn request(injector: &Injector, info: RequestInfo) -> InjectResult<Self> {
+    fn request(injector: &Injector, info: &RequestInfo) -> InjectResult<Self> {
         Ok(Factory {
             injector: injector.clone(),
-            request_info: info,
+            request_info: info.clone(),
             marker: PhantomData,
         })
     }

--- a/crates/runtime_injector/src/services/constant.rs
+++ b/crates/runtime_injector/src/services/constant.rs
@@ -32,7 +32,7 @@ where
     fn provide_typed(
         &mut self,
         _injector: &Injector,
-        _request_info: RequestInfo,
+        _request_info: &RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
         Ok(self.result.clone())
     }

--- a/crates/runtime_injector/src/services/fallible.rs
+++ b/crates/runtime_injector/src/services/fallible.rs
@@ -1,4 +1,7 @@
-use crate::{InjectError, InjectResult, Service, ServiceFactory, ServiceInfo};
+use crate::{
+    InjectError, InjectResult, Injector, RequestInfo, Service, ServiceFactory,
+    ServiceInfo,
+};
 use std::{error::Error, marker::PhantomData};
 
 /// A service factory that may fail during service creation with a custom error
@@ -26,8 +29,8 @@ where
 
     fn invoke(
         &mut self,
-        injector: &crate::Injector,
-        request_info: crate::RequestInfo,
+        injector: &Injector,
+        request_info: &RequestInfo,
     ) -> InjectResult<Self::Result> {
         let result = self.inner.invoke(injector, request_info)?;
         match result {

--- a/crates/runtime_injector/src/services/func.rs
+++ b/crates/runtime_injector/src/services/func.rs
@@ -33,7 +33,7 @@ pub trait ServiceFactory<D>: Service {
     fn invoke(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Self::Result>;
 }
 
@@ -58,11 +58,11 @@ macro_rules! impl_provider_function {
             fn invoke(
                 &mut self,
                 injector: &Injector,
-                request_info: RequestInfo
+                request_info: &RequestInfo
             ) -> InjectResult<Self::Result> {
                 let request_info = request_info.with_request(ServiceInfo::of::<R>());
                 let result = self($(
-                    match <$type_name as Request>::request(&injector, request_info.clone()) {
+                    match <$type_name as Request>::request(&injector, &request_info) {
                         Ok(dependency) => dependency,
                         Err($crate::InjectError::MissingProvider { service_info }) => {
                             return Err($crate::InjectError::MissingDependency {

--- a/crates/runtime_injector/src/services/func.rs
+++ b/crates/runtime_injector/src/services/func.rs
@@ -22,7 +22,7 @@ use crate::{
 ///     todo!()
 /// }
 /// let injector: Injector = todo!();
-/// factory.invoke(&injector, RequestInfo::new());
+/// factory.invoke(&injector, &RequestInfo::new());
 /// # }
 /// ```
 pub trait ServiceFactory<D>: Service {

--- a/crates/runtime_injector/src/services/func.rs
+++ b/crates/runtime_injector/src/services/func.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{
     InjectResult, Injector, Request, RequestInfo, Service, ServiceInfo,
 };
@@ -27,7 +25,7 @@ use crate::{
 /// factory.invoke(&injector, RequestInfo::new());
 /// # }
 /// ```
-pub trait ServiceFactory<D>: Any {
+pub trait ServiceFactory<D>: Service {
     /// The resulting service from invoking this service factory.
     type Result: Service;
 
@@ -50,7 +48,7 @@ macro_rules! impl_provider_function {
     (@impl ($($type_name:ident),*)) => {
         impl<F, R $(, $type_name)*> ServiceFactory<($($type_name,)*)> for F
         where
-            F: Any + FnMut($($type_name),*) -> R,
+            F: Service + FnMut($($type_name),*) -> R,
             R: Service,
             $($type_name: Request,)*
         {

--- a/crates/runtime_injector/src/services/providers.rs
+++ b/crates/runtime_injector/src/services/providers.rs
@@ -19,14 +19,14 @@ pub trait Provider: Service {
     fn provide(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<DynSvc>;
 
     /// Provides an owned instance of the service.
     fn provide_owned(
         &mut self,
         _injector: &Injector,
-        _request_info: RequestInfo,
+        _request_info: &RequestInfo,
     ) -> InjectResult<OwnedDynSvc> {
         Err(InjectError::OwnedNotSupported {
             service_info: self.result(),
@@ -45,7 +45,7 @@ where
     fn provide(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<DynSvc> {
         let result = self.provide_typed(injector, request_info)?;
         Ok(result as DynSvc)
@@ -54,7 +54,7 @@ where
     fn provide_owned(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<OwnedDynSvc> {
         let result = self.provide_owned_typed(injector, request_info)?;
         Ok(result as OwnedDynSvc)
@@ -86,7 +86,7 @@ where
 ///     fn provide_typed(
 ///         &mut self,
 ///         _injector: &Injector,
-///         _request_info: RequestInfo,
+///         _request_info: &RequestInfo,
 ///     ) -> InjectResult<Svc<Self::Result>> {
 ///         Ok(Svc::new(Foo))
 ///     }
@@ -107,7 +107,7 @@ pub trait TypedProvider: Sized + Provider {
     fn provide_typed(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Svc<Self::Result>>;
 
     /// Provides an owned instance of the service. Not all providers can
@@ -115,7 +115,7 @@ pub trait TypedProvider: Sized + Provider {
     fn provide_owned_typed(
         &mut self,
         _injector: &Injector,
-        _request_info: RequestInfo,
+        _request_info: &RequestInfo,
     ) -> InjectResult<Box<Self::Result>> {
         Err(InjectError::OwnedNotSupported {
             service_info: ServiceInfo::of::<Self::Result>(),
@@ -191,7 +191,7 @@ where
     fn provide(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<DynSvc> {
         self.inner.provide(injector, request_info)
     }
@@ -199,7 +199,7 @@ where
     fn provide_owned(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<OwnedDynSvc> {
         self.inner.provide_owned(injector, request_info)
     }

--- a/crates/runtime_injector/src/services/singleton.rs
+++ b/crates/runtime_injector/src/services/singleton.rs
@@ -37,7 +37,7 @@ impl<D, R, F> TypedProvider for SingletonProvider<D, R, F>
 where
     D: Service,
     R: Service,
-    F: ServiceFactory<D, Result = R> + Service,
+    F: ServiceFactory<D, Result = R>,
 {
     type Result = R;
 

--- a/crates/runtime_injector/src/services/singleton.rs
+++ b/crates/runtime_injector/src/services/singleton.rs
@@ -44,7 +44,7 @@ where
     fn provide_typed(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
         if let Some(ref service) = self.result {
             return Ok(service.clone());

--- a/crates/runtime_injector/src/services/transient.rs
+++ b/crates/runtime_injector/src/services/transient.rs
@@ -35,7 +35,7 @@ impl<D, R, F> TypedProvider for TransientProvider<D, R, F>
 where
     D: Service,
     R: Service,
-    F: ServiceFactory<D, Result = R> + Service,
+    F: ServiceFactory<D, Result = R>,
 {
     type Result = R;
 

--- a/crates/runtime_injector/src/services/transient.rs
+++ b/crates/runtime_injector/src/services/transient.rs
@@ -42,7 +42,7 @@ where
     fn provide_typed(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Svc<Self::Result>> {
         let result = self.factory.invoke(injector, request_info)?;
         Ok(Svc::new(result))
@@ -51,7 +51,7 @@ where
     fn provide_owned_typed(
         &mut self,
         injector: &Injector,
-        request_info: RequestInfo,
+        request_info: &RequestInfo,
     ) -> InjectResult<Box<Self::Result>> {
         let result = self.factory.invoke(injector, request_info)?;
         Ok(Box::new(result))

--- a/crates/runtime_injector_actix/Cargo.toml
+++ b/crates/runtime_injector_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_injector_actix"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 authors = ["TehPers <tehperz@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ actix-web = "3"
 futures-util = "0.3"
 
 [dependencies.runtime_injector]
-version = "0.3"
+version = "0.4"
 path = "../runtime_injector"
 default_features = false
 features = ["arc"]

--- a/crates/runtime_injector_actix/src/lib.rs
+++ b/crates/runtime_injector_actix/src/lib.rs
@@ -1,10 +1,13 @@
 //! Utility library for injecting dependencies into actix-web applications.
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs, clippy::all, clippy::pedantic)]
+#![deny(clippy::all, clippy::pedantic)]
+#![warn(missing_docs)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::missing_errors_doc,
+    clippy::doc_markdown,
+    clippy::needless_doctest_main,
     clippy::needless_pass_by_value
 )]
 


### PR DESCRIPTION
Cleans up existing code. This includes breaking changes.

- Reduces number of times `RequestInfo` is cloned by changing signatures to take `&RequestInfo` instead of `RequestInfo`
- Made `ServiceFactory<D>` be a subtrait of `Service` since providers need to implement `Service` anyway
- Fixed `Clone` implementation for `Factory<R>` requiring `R: Clone` (limitation of `#[derive(Clone)]`)
- Added additional example to `Factory`
- Fixed CI not failing on clippy failures
- Incremented version numbers for runtime_injector and runtime_injector_actix