### PR TITLE
Add conditional providers

### DIFF
--- a/crates/runtime_injector/src/iter.rs
+++ b/crates/runtime_injector/src/iter.rs
@@ -222,7 +222,7 @@ impl<'a, I: ?Sized + Interface> Iterator for ServicesIter<'a, I> {
         } = self;
 
         provider_iter
-            .filter_map(|provider| {
+            .find_map(|provider| {
                 match provider.provide(injector, request_info) {
                     Ok(result) => Some(I::downcast(result)),
                     Err(InjectError::ConditionsNotMet { .. }) => None,
@@ -237,7 +237,6 @@ impl<'a, I: ?Sized + Interface> Iterator for ServicesIter<'a, I> {
                     Err(error) => Some(Err(error)),
                 }
             })
-            .next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -295,7 +294,7 @@ impl<'a, I: ?Sized + Interface> Iterator for OwnedServicesIter<'a, I> {
         } = self;
 
         provider_iter
-            .filter_map(|provider| {
+            .find_map(|provider| {
                 match provider.provide_owned(injector, request_info) {
                     Ok(result) => Some(I::downcast_owned(result)),
                     Err(InjectError::ConditionsNotMet { .. }) => None,
@@ -310,6 +309,9 @@ impl<'a, I: ?Sized + Interface> Iterator for OwnedServicesIter<'a, I> {
                     Err(error) => Some(Err(error)),
                 }
             })
-            .next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.provider_iter.len()))
     }
 }

--- a/crates/runtime_injector/src/iter.rs
+++ b/crates/runtime_injector/src/iter.rs
@@ -222,7 +222,7 @@ impl<'a, I: ?Sized + Interface> Iterator for ServicesIter<'a, I> {
         } = self;
 
         provider_iter
-            .flat_map(|provider| {
+            .filter_map(|provider| {
                 match provider.provide(injector, request_info) {
                     Ok(result) => Some(I::downcast(result)),
                     Err(InjectError::ConditionsNotMet { .. }) => None,
@@ -295,7 +295,7 @@ impl<'a, I: ?Sized + Interface> Iterator for OwnedServicesIter<'a, I> {
         } = self;
 
         provider_iter
-            .flat_map(|provider| {
+            .filter_map(|provider| {
                 match provider.provide_owned(injector, request_info) {
                     Ok(result) => Some(I::downcast_owned(result)),
                     Err(InjectError::ConditionsNotMet { .. }) => None,

--- a/crates/runtime_injector/src/services.rs
+++ b/crates/runtime_injector/src/services.rs
@@ -1,3 +1,4 @@
+mod conditional;
 mod constant;
 mod fallible;
 mod func;
@@ -7,6 +8,7 @@ mod service;
 mod singleton;
 mod transient;
 
+pub use conditional::*;
 pub use constant::*;
 pub use fallible::*;
 pub use func::*;

--- a/crates/runtime_injector/src/services/conditional.rs
+++ b/crates/runtime_injector/src/services/conditional.rs
@@ -1,0 +1,101 @@
+use crate::{
+    InjectError, InjectResult, Injector, RequestInfo, Service, ServiceInfo,
+    Svc, TypedProvider,
+};
+
+/// A [`TypedProvider`] which conditionally provides its service. If the
+/// condition is not met, then the provider is skipped during resolution.
+///
+/// See the [docs for `WithCondition`](crate::WithCondition) for more
+/// information.
+pub struct ConditionalProvider<P, F>
+where
+    P: TypedProvider,
+    F: Service + Fn(&Injector, &RequestInfo) -> bool,
+{
+    inner: P,
+    condition: F,
+}
+
+impl<P, F> TypedProvider for ConditionalProvider<P, F>
+where
+    P: TypedProvider,
+    F: Service + Fn(&Injector, &RequestInfo) -> bool,
+{
+    type Result = P::Result;
+
+    #[inline]
+    fn provide_typed(
+        &mut self,
+        injector: &Injector,
+        request_info: &RequestInfo,
+    ) -> InjectResult<Svc<Self::Result>> {
+        if (self.condition)(injector, request_info) {
+            self.inner.provide_typed(injector, request_info)
+        } else {
+            Err(InjectError::ConditionsNotMet {
+                service_info: ServiceInfo::of::<Self::Result>(),
+            })
+        }
+    }
+
+    #[inline]
+    fn provide_owned_typed(
+        &mut self,
+        injector: &Injector,
+        request_info: &RequestInfo,
+    ) -> InjectResult<Box<Self::Result>> {
+        if (self.condition)(injector, request_info) {
+            self.inner.provide_owned_typed(injector, request_info)
+        } else {
+            Err(InjectError::ConditionsNotMet {
+                service_info: ServiceInfo::of::<Self::Result>(),
+            })
+        }
+    }
+}
+
+/// Defines a conversion into a conditional provider. This trait is
+/// automatically implemented for all types that implement [`TypedProvider`].
+pub trait WithCondition: TypedProvider {
+    /// Creates a conditional provider. Conditional providers create their
+    /// values only if their condition is met. If the condition is not met,
+    /// then the provider is skipped.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use runtime_injector::{Injector, IntoSingleton, Svc, WithCondition};
+    ///
+    /// #[derive(Default)]
+    /// struct Foo;
+    ///
+    /// let mut builder = Injector::builder();
+    /// builder.provide(Foo::default.singleton().with_condition(|_, _| false));
+    ///
+    /// let injector = builder.build();
+    /// let foo: Option<Svc<Foo>> = injector.get().unwrap();
+    ///
+    /// assert!(foo.is_none());
+    /// ```
+    #[must_use]
+    fn with_condition<F>(self, condition: F) -> ConditionalProvider<Self, F>
+    where
+        F: Service + Fn(&Injector, &RequestInfo) -> bool;
+}
+
+impl<P> WithCondition for P
+where
+    P: TypedProvider,
+{
+    #[inline]
+    fn with_condition<F>(self, condition: F) -> ConditionalProvider<Self, F>
+    where
+        F: Service + Fn(&Injector, &RequestInfo) -> bool,
+    {
+        ConditionalProvider {
+            condition,
+            inner: self,
+        }
+    }
+}

--- a/crates/runtime_injector/src/services/service.rs
+++ b/crates/runtime_injector/src/services/service.rs
@@ -168,6 +168,13 @@ pub enum InjectError {
         service_info: ServiceInfo,
     },
 
+    /// This provider's conditions for providing its service have not and it
+    /// should be ignored.
+    ConditionsNotMet {
+        /// The service that was requested.
+        service_info: ServiceInfo,
+    },
+
     /// An error occurred during activation of a service.
     ActivationFailed {
         /// The service that was requested.
@@ -195,12 +202,12 @@ impl Display for InjectError {
         write!(f, "an error occurred during injection: ")?;
         match self {
             InjectError::MissingProvider { service_info } => {
-                write!(f, "{} has no provider", service_info.name())?
+                write!(f, "{} has no provider", service_info.name())
             }
             InjectError::MissingDependency {
                 service_info,
                 ..
-            } => write!(f, "{} is missing a dependency", service_info.name())?,
+            } => write!(f, "{} is missing a dependency", service_info.name()),
             InjectError::CycleDetected {
                 service_info,
                 cycle,
@@ -209,7 +216,7 @@ impl Display for InjectError {
                 "a cycle was detected during activation of {} [{}]",
                 service_info.name(),
                 fmt_cycle(cycle)
-            )?,
+            ),
             InjectError::InvalidImplementation {
                 service_info,
                 implementation,
@@ -218,9 +225,9 @@ impl Display for InjectError {
                 "{} is not registered as an implementer of {}",
                 implementation.name(),
                 service_info.name()
-            )?,
+            ),
             InjectError::InvalidProvider { service_info } => {
-                write!(f, "the registered provider for {} returned the wrong type", service_info.name())?
+                write!(f, "the registered provider for {} returned the wrong type", service_info.name())
             }
             InjectError::MultipleProviders {
                 service_info,
@@ -230,23 +237,28 @@ impl Display for InjectError {
                 "the requested service {} has {} providers registered (did you mean to request a Services<T> instead?)",
                 service_info.name(),
                 providers
-            )?,
+            ),
             InjectError::OwnedNotSupported {
                 service_info
             } => write!(
                 f,
                 "the registered provider can't provide an owned variant of {}",
                 service_info.name()
-            )?,
+            ),
+            InjectError::ConditionsNotMet { service_info } => {
+                write!(
+                    f,
+                    "the conditions for providing the service {} have not been met",
+                    service_info.name()
+                )
+            }
             InjectError::ActivationFailed { service_info, .. } => {
-                write!(f, "an error occurred during activation of {}", service_info.name())?
+                write!(f, "an error occurred during activation of {}", service_info.name())
             },
             InjectError::InternalError(message) => {
-                write!(f, "an unexpected error occurred (please report this): {}", message)?
+                write!(f, "an unexpected error occurred (please report this): {}", message)
             },
-        };
-
-        Ok(())
+        }
     }
 }
 

--- a/crates/runtime_injector/src/services/service.rs
+++ b/crates/runtime_injector/src/services/service.rs
@@ -170,6 +170,11 @@ pub enum InjectError {
 
     /// This provider's conditions for providing its service have not and it
     /// should be ignored.
+    ///
+    /// Returning this from a provider causes the provider to be ignored during
+    /// service resolution. See [`ConditionalProvider`] for more information.
+    ///
+    /// [`ConditionalProvider`]: crate::ConditionalProvider
     ConditionsNotMet {
         /// The service that was requested.
         service_info: ServiceInfo,


### PR DESCRIPTION
Adds conditional providers which are skipped if their condition is not met. Currently only `TypedProvider`s can be nested in `ConditionalProvider`. Hopefully when GATs are eventually released `WithCondition` can also be implemented on `Provider`.

Resolves #29 